### PR TITLE
Improve state models and measurement models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # 📜 BayesFilters changelog
 
+## Version 0.9.101
+##### `CMake`
+ - Third number of SemVer increases since API compatibility is broken.
+
+##### `Filtering Features`
+
+###### State models
+ - Removed method StateModel::getNoiseCovarianceMatrix.
+ - Removed method StateModel::getNoiseSample.
+ - Removed method StateModelDecorator::getNoiseCovarianceMatrix.
+ - Removed method StateModelDecorator::getNoiseSample.
+ - Added non-pure virtual method StateModel::transitionProbability.
+ - Added non-pure virtual method StateModel::getJacobian.
+ - Implemented AdditiveStateModel class inheriting from StateModel.
+ - Implemented LinearStateModel class inheriting from AdditiveStateModel.
+ - Implemented LTIStateModel class inheriting from LinearStateModel.
+ - Method WhiteNoiseAcceleration::getNoiseSample do not override.
+ - WhiteNoiseAcceleration class now inherits from LinearStateModel.
+ - SimulatedStateModel class now supports state vector of any size.
+
+###### Measurement models
+ - Removed method MeasurementModel::getNoiseSample.
+ - Removed method MeasurementModelDecorator::getNoiseSample.
+ - Added class LinearMeasurementModel.
+ - Added class LTIMeasurementModel.
+ - LinearModel class now inherits from LinearMeasurementModel.
+ - Method MeasurementModel::measure replaces method MeasurementModel::getAgentMeasurements and does not take the state as input.
+ - Method MeasurementModelDecorator::measure replaces method MeasurementModelDecorator::getAgentMesurements.
+ - Method SimulatedLinearSensor::measure replaces method SimulatedLinearSensor::getAgentMeasurements.
+ - LinearModel class now does not implement MeasurementModel::measure.
+ - SimulatedLinearModel class inheriting from LinearModel implements method MeasurementModel::measure.
+ - Method GaussianLilkelihood::likelihood uses method MeasurementModel::measure.
+ - Method MeasurementModel::freezeMeasurements replaces method MeasurementModel::bufferAgentData const.
+ - Method MeasurementModelDecorator::freezeMeasurements replaces method MeasurementModelDecorator::bufferAgentData const.
+ - Method SimulatedLinearSensor::freezeMeasurements replaces method SimulatedLinearSensors::bufferAgentData const.
+ - Moved actual evaluation of measurements from SimulatedLinearSensor::measure to SimulatedLinearSensors::freezeMeasurements.
+ - Method UpdateParticles::correctStep uses MeasurementModel::freezeMeasurements.
+
+##### `Test`
+ - Updated test_SIS_Decorators (since use MeasurementModelDecorator).
+
 ## Version 0.8.101
 ##### `CMake`
  - Third number of SemVer increases since API compatibility is broken

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,47 @@
 # 📜 BayesFilters changelog
 
-## Version 0.9.101
+## Version 0.8.100
+##### `Dependencies`
+ - Removed OpenCV dependency.
+
 ##### `CMake`
+ - Devel branch will now have +100 on the patch number to differentiate from master branch.
+ - Fourth number of the project version has been removed to be compliant with SemVer system.
  - Third number of SemVer increases since API compatibility is broken.
 
-##### `Filtering Features`
+##### `Filtering Algorithms`
+ - Constructor SIS::SIS takes the state size as argument (required to initialize ParticleSet).
+ - Method SIS::filteringStep uses VectorXi instead of VectorXf to represent particle parents.
+
+##### `Filtering Functions`
+ - Removed VisualParticleFilter class.
+ - Removed PFVisualCorrection and derived classes.
+ - Added getter and setter methods to PFCorrection and derived classes for Process class.
+ - Added Process interface class to model a generic processes.
+ - Added LikelihoodModel interface class to model generic likelihood models.
+ - Added GaussianLikelihood class to model a likelihood for a linear process model with Gaussian distrubances.
+ - PFCorrection::getLikelihood() method is now pure virtual.
+ - Used ParticleSet class within classes PFPrediction, PFPredictionDecorator, PFCorrection, PFCorrectionDecorator, DrawParticles, UpdateParticles, Resampling, ResamplingWithPrior, ParticleSetInitialization, InitSurveillanceAreaGrid and SIS.
+ - Method ResamplingWithPrior::resample heavily changed (due to use of ParticleSet).
+ - Methods Resampling::resample and ResamplingWithPrior::resample use VectorXi instead of VectorXf to represent particle parents.
 
 ###### State models
+ - Added SimulatedStateModel class to simulate kinematic or dynamic models using StateModel classes.
  - Removed method StateModel::getNoiseCovarianceMatrix.
  - Removed method StateModel::getNoiseSample.
  - Removed method StateModelDecorator::getNoiseCovarianceMatrix.
  - Removed method StateModelDecorator::getNoiseSample.
- - Added non-pure virtual method StateModel::transitionProbability.
+ - Added non-pure virtual method StateModel::getTransitionProbability.
  - Added non-pure virtual method StateModel::getJacobian.
  - Implemented AdditiveStateModel class inheriting from StateModel.
  - Implemented LinearStateModel class inheriting from AdditiveStateModel.
  - Implemented LTIStateModel class inheriting from LinearStateModel.
- - Method WhiteNoiseAcceleration::getNoiseSample do not override.
  - WhiteNoiseAcceleration class now inherits from LinearStateModel.
  - SimulatedStateModel class now supports state vector of any size.
 
 ###### Measurement models
+ - MeasurementModel and direved classes now have registerProcessData() to register a GenericData coming from a process.
+ - MeasurementModel and direved classes now have getProcessMeasurements() to provide meaurements of the registered GenericData of a process.
  - Removed method MeasurementModel::getNoiseSample.
  - Removed method MeasurementModelDecorator::getNoiseSample.
  - Added class LinearMeasurementModel.
@@ -38,14 +59,15 @@
  - Moved actual evaluation of measurements from SimulatedLinearSensor::measure to SimulatedLinearSensors::freezeMeasurements.
  - Method UpdateParticles::correctStep uses MeasurementModel::freezeMeasurements.
 
-##### `Test`
- - Updated test_SIS_Decorators (since use MeasurementModelDecorator).
-
-## Version 0.8.101
-##### `CMake`
- - Third number of SemVer increases since API compatibility is broken
-
 ##### `Filtering Utilities`
+ - Added Particle and ParticleSet classes.
+ - Added GenericData class in order to have a type for encapsulating data coming from any process.
+ - Added EigenMatrixData class that inherits from Generic data and Eigen::Matrix class.
+ - Added EigenVectorXfData, EigenMatrixXfData, EigenMatrixXcfData, EigenVectorXdData, EigenMatrixXdData, EigenMatrixXcdData typedefs of EigenMatrixData.
+ - Added Gaussian and GaussianMixture classes.
+ - Added directional_add(), directional_sub() and directional_mean() functions in directionalstatisticsutils.h/cpp.
+ - Added unscented_weights() and unscented_transform() functions in sigmapointutils.h/cpp.
+ - Added logging capabilities to FilteringAlgorithm, GenericData, MeasurementModel and Process interfaces.
  - Removed GaussianRef class.
  - Added methods to get the i-th mean, covariance and weight of a GaussianMixture.
  - Added accessors to single elements of the mean/covariance in GaussianMixture class.
@@ -54,54 +76,16 @@
  - Removed Particle class.
  - Implemented ParticleSet class as inheriring from GaussianMixture class.
 
-##### `Filtering Classes`
- - Constructor SIS::SIS takes the state size as argument (required to initialize ParticleSet).
- - Method SIS::filteringStep uses VectorXi instead of VectorXf to represent particle parents.
-
-##### `Filtering Features`
- - Used ParticleSet class within classes PFPrediction, PFPredictionDecorator, PFCorrection, PFCorrectionDecorator, DrawParticles, UpdateParticles, Resampling, ResamplingWithPrior, ParticleSetInitialization, InitSurveillanceAreaGrid and SIS.
- - Method ResamplingWithPrior::resample heavily changed (due to use of ParticleSet).
- - Methods Resampling::resample and ResamplingWithPrior::resample use VectorXi instead of VectorXf to represent particle parents.
-
 ##### `Test`
+ - Added a test for directionalstatisticsutils.h/cpp.
+ - Added a test for sigmapointutils.h/cpp.
+ - Added a test for Gaussian and GaussianMixture classes.
+ - Updated test_SIS_Decorators (since use MeasurementModelDecorator).
  - Updated test_Gaussian (since use Gaussian class).
  - Fix typo in test_Gaussian (since returning in case of failure outside the catch block).
  - Updated test_SigmaPointUtils (since use Gaussian class).
  - Updated test_SIS (since use SIS class).
  - Updated test_SIS_Decorators (since use classes PFPredictionDecorator, PFCorrectionDecorator and SIS)
-
-## Version 0.7.101
-##### `Dependencies`
- - Removed OpenCV dependency.
-
-###### `CMake`
- - Devel branch will now have +100 on the patch number to differentiate from master branch.
- - Fourth number of the project version has been removed to be compliant with SemVer system.
- - Added a test for directionalstatisticsutils.h/cpp.
- - Added a test for sigmapointutils.h/cpp.
- - Added a test for Gaussian and GaussianMixture classes.
-
-##### `Filtering classes`
- - Removed VisualParticleFilter class.
- - Removed PFVisualCorrection and derived classes.
- - Added GenericData class in order to have a type for encapsulating data coming from any process.
- - Added EigenMatrixData class that inherits from Generic data and Eigen::Matrix class.
- - Added EigenVectorXfData, EigenMatrixXfData, EigenMatrixXcfData, EigenVectorXdData, EigenMatrixXdData, EigenMatrixXcdData typedefs of EigenMatrixData.
- - MeasurementModel and direved classes now have registerProcessData() to register a GenericData coming from a process.
- - MeasurementModel and direved classes now have getProcessMeasurements() to provide meaurements of the registered GenericData of a process.
- - Added getter and setter methods to PFCorrection and derived classes for Process class.
- - Added Process interface class to model a generic processes.
- - Added SimulatedStateModel class to simulate kinematic or dynamic models using StateModel classes.
- - Added LikelihoodModel interface class to model generic likelihood models.
- - Added GaussianLikelihood class to model a likelihood for a linear process model with Gaussian distrubances.
- - Added Gaussian and GaussianMixture classes.
- - Added Particle and ParticleSet classes.
- - PFCorrection::getLikelihood() method is now pure virtual.
-
-##### `Filtering Features`
- - Added directional_add(), directional_sub() and directional_mean() functions in directionalstatisticsutils.h/cpp.
- - Added unscented_weights() and unscented_transform() functions in sigmapointutils.h/cpp.
- - Added logging capabilities to FilteringAlgorithm, GenericData, MeasurementModel and Process interfaces.
 
 
 ## Version 0.7.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 📜 BayesFilters changelog
 
 ## Version 0.8.100
+
 ##### `Dependencies`
  - Removed OpenCV dependency.
 
@@ -10,18 +11,17 @@
  - Third number of SemVer increases since API compatibility is broken.
 
 ##### `Filtering Algorithms`
+ - Added logging capabilities to FilteringAlgorithm.
  - Constructor SIS::SIS takes the state size as argument (required to initialize ParticleSet).
  - Method SIS::filteringStep uses VectorXi instead of VectorXf to represent particle parents.
 
 ##### `Filtering Functions`
  - Removed VisualParticleFilter class.
  - Removed PFVisualCorrection and derived classes.
- - Added getter and setter methods to PFCorrection and derived classes for Process class.
- - Added Process interface class to model a generic processes.
- - Added LikelihoodModel interface class to model generic likelihood models.
- - Added GaussianLikelihood class to model a likelihood for a linear process model with Gaussian distrubances.
+ - Added LikelihoodModel interface class.
+ - Added GaussianLikelihood class.
  - PFCorrection::getLikelihood() method is now pure virtual.
- - Used ParticleSet class within classes PFPrediction, PFPredictionDecorator, PFCorrection, PFCorrectionDecorator, DrawParticles, UpdateParticles, Resampling, ResamplingWithPrior, ParticleSetInitialization, InitSurveillanceAreaGrid and SIS.
+ - Used new ParticleSet class within classes PFPrediction, PFPredictionDecorator, PFCorrection, PFCorrectionDecorator, DrawParticles, UpdateParticles, Resampling, ResamplingWithPrior, ParticleSetInitialization, InitSurveillanceAreaGrid and SIS.
  - Method ResamplingWithPrior::resample heavily changed (due to use of ParticleSet).
  - Methods Resampling::resample and ResamplingWithPrior::resample use VectorXi instead of VectorXf to represent particle parents.
 
@@ -37,55 +37,33 @@
  - Implemented LinearStateModel class inheriting from AdditiveStateModel.
  - Implemented LTIStateModel class inheriting from LinearStateModel.
  - WhiteNoiseAcceleration class now inherits from LinearStateModel.
- - SimulatedStateModel class now supports state vector of any size.
 
 ###### Measurement models
- - MeasurementModel and direved classes now have registerProcessData() to register a GenericData coming from a process.
- - MeasurementModel and direved classes now have getProcessMeasurements() to provide meaurements of the registered GenericData of a process.
+ - Added SimulatedLinearSensor class.
+ - Added MeasurementModelDecorator class.
+ - Added logging capabilities to MeasurementModel.
  - Removed method MeasurementModel::getNoiseSample.
- - Removed method MeasurementModelDecorator::getNoiseSample.
+ - Method MeasurementModel::measure replaces method MeasurementModel::getAgentMeasurements and does not take the state as input.
+ - Method MeasurementModel::freezeMeasurements replaces method MeasurementModel::bufferAgentData const.
+ - Method UpdateParticles::correctStep uses MeasurementModel::freezeMeasurements.
  - Added class LinearMeasurementModel.
  - Added class LTIMeasurementModel.
+ - Renamed LinearSensor to LinearModel.
  - LinearModel class now inherits from LinearMeasurementModel.
- - Method MeasurementModel::measure replaces method MeasurementModel::getAgentMeasurements and does not take the state as input.
- - Method MeasurementModelDecorator::measure replaces method MeasurementModelDecorator::getAgentMesurements.
- - Method SimulatedLinearSensor::measure replaces method SimulatedLinearSensor::getAgentMeasurements.
  - LinearModel class now does not implement MeasurementModel::measure.
- - SimulatedLinearModel class inheriting from LinearModel implements method MeasurementModel::measure.
- - Method GaussianLilkelihood::likelihood uses method MeasurementModel::measure.
- - Method MeasurementModel::freezeMeasurements replaces method MeasurementModel::bufferAgentData const.
- - Method MeasurementModelDecorator::freezeMeasurements replaces method MeasurementModelDecorator::bufferAgentData const.
- - Method SimulatedLinearSensor::freezeMeasurements replaces method SimulatedLinearSensors::bufferAgentData const.
- - Moved actual evaluation of measurements from SimulatedLinearSensor::measure to SimulatedLinearSensors::freezeMeasurements.
- - Method UpdateParticles::correctStep uses MeasurementModel::freezeMeasurements.
 
 ##### `Filtering Utilities`
- - Added Particle and ParticleSet classes.
- - Added GenericData class in order to have a type for encapsulating data coming from any process.
- - Added EigenMatrixData class that inherits from Generic data and Eigen::Matrix class.
- - Added EigenVectorXfData, EigenMatrixXfData, EigenMatrixXcfData, EigenVectorXdData, EigenMatrixXdData, EigenMatrixXcdData typedefs of EigenMatrixData.
- - Added Gaussian and GaussianMixture classes.
- - Added directional_add(), directional_sub() and directional_mean() functions in directionalstatisticsutils.h/cpp.
- - Added unscented_weights() and unscented_transform() functions in sigmapointutils.h/cpp.
- - Added logging capabilities to FilteringAlgorithm, GenericData, MeasurementModel and Process interfaces.
- - Removed GaussianRef class.
- - Added methods to get the i-th mean, covariance and weight of a GaussianMixture.
- - Added accessors to single elements of the mean/covariance in GaussianMixture class.
- - Re-implemented Gaussian class as inheriting from GaussianMixture class.
- - Added accessors to single elements of the mean/covariance in Gaussian class.
- - Removed Particle class.
- - Implemented ParticleSet class as inheriring from GaussianMixture class.
+ - Added Data class in order to have a type for encapsulating data coming from any process.
+ - Added GaussianMixture, Gaussian and ParticleSet classes.
+ - Added directional_add(), directional_sub() and directional_mean() functions in directional_statistics.h/cpp.
+ - Added unscented_weights() and unscented_transform() functions in sigma_point.h/cpp.
 
 ##### `Test`
- - Added a test for directionalstatisticsutils.h/cpp.
- - Added a test for sigmapointutils.h/cpp.
- - Added a test for Gaussian and GaussianMixture classes.
- - Updated test_SIS_Decorators (since use MeasurementModelDecorator).
- - Updated test_Gaussian (since use Gaussian class).
- - Fix typo in test_Gaussian (since returning in case of failure outside the catch block).
- - Updated test_SigmaPointUtils (since use Gaussian class).
- - Updated test_SIS (since use SIS class).
- - Updated test_SIS_Decorators (since use classes PFPredictionDecorator, PFCorrectionDecorator and SIS)
+ - Added test_DirectionalStatisticsUtils for directional_statistics.h/cpp.
+ - Added test_SigmaPointUtils for sigma_point.h/cpp.
+ - Added test_Gaussian for Gaussian and GaussianMixture classes.
+ - Updated test_SIS.
+ - Updated test_SIS_Decorators.
 
 
 ## Version 0.7.1.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ endif()
 
 project(BayesFilters
         LANGUAGES CXX
-        VERSION 0.9.101)
+        VERSION 0.8.100)
 
 set(CMAKE_CXX_STANDARD 11)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ endif()
 
 project(BayesFilters
         LANGUAGES CXX
-        VERSION 0.8.101)
+        VERSION 0.9.101)
 
 set(CMAKE_CXX_STANDARD 11)
 

--- a/src/BayesFilters/CMakeLists.txt
+++ b/src/BayesFilters/CMakeLists.txt
@@ -26,6 +26,7 @@ set(${LIBRARY_TARGET_NAME}_FF_HDR
         include/BayesFilters/LinearMeasurementModel.h
         include/BayesFilters/LinearModel.h
         include/BayesFilters/LinearStateModel.h
+        include/BayesFilters/LTIMeasurementModel.h
         include/BayesFilters/LTIStateModel.h
         include/BayesFilters/MeasurementModel.h
         include/BayesFilters/MeasurementModelDecorator.h
@@ -92,6 +93,7 @@ set(${LIBRARY_TARGET_NAME}_FF_SRC
         src/LinearMeasurementModel.cpp
         src/LinearModel.cpp
         src/LinearStateModel.cpp
+        src/LTIMeasurementModel.cpp
         src/LTIStateModel.cpp
         src/MeasurementModel.cpp
         src/MeasurementModelDecorator.cpp

--- a/src/BayesFilters/CMakeLists.txt
+++ b/src/BayesFilters/CMakeLists.txt
@@ -24,6 +24,7 @@ set(${LIBRARY_TARGET_NAME}_FF_HDR
         include/BayesFilters/InitSurveillanceAreaGrid.h
         include/BayesFilters/LikelihoodModel.h
         include/BayesFilters/LinearModel.h
+        include/BayesFilters/LinearStateModel.h
         include/BayesFilters/MeasurementModel.h
         include/BayesFilters/MeasurementModelDecorator.h
         include/BayesFilters/ParticleSetInitialization.h
@@ -87,6 +88,7 @@ set(${LIBRARY_TARGET_NAME}_FF_SRC
         src/GaussianLikelihood.cpp
         src/InitSurveillanceAreaGrid.cpp
         src/LinearModel.cpp
+        src/LinearStateModel.cpp
         src/MeasurementModel.cpp
         src/MeasurementModelDecorator.cpp
         src/PFCorrection.cpp

--- a/src/BayesFilters/CMakeLists.txt
+++ b/src/BayesFilters/CMakeLists.txt
@@ -25,6 +25,7 @@ set(${LIBRARY_TARGET_NAME}_FF_HDR
         include/BayesFilters/LikelihoodModel.h
         include/BayesFilters/LinearModel.h
         include/BayesFilters/LinearStateModel.h
+        include/BayesFilters/LTIStateModel.h
         include/BayesFilters/MeasurementModel.h
         include/BayesFilters/MeasurementModelDecorator.h
         include/BayesFilters/ParticleSetInitialization.h
@@ -89,6 +90,7 @@ set(${LIBRARY_TARGET_NAME}_FF_SRC
         src/InitSurveillanceAreaGrid.cpp
         src/LinearModel.cpp
         src/LinearStateModel.cpp
+        src/LTIStateModel.cpp
         src/MeasurementModel.cpp
         src/MeasurementModelDecorator.cpp
         src/PFCorrection.cpp

--- a/src/BayesFilters/CMakeLists.txt
+++ b/src/BayesFilters/CMakeLists.txt
@@ -23,6 +23,7 @@ set(${LIBRARY_TARGET_NAME}_FF_HDR
         include/BayesFilters/GaussianInitialization.h
         include/BayesFilters/InitSurveillanceAreaGrid.h
         include/BayesFilters/LikelihoodModel.h
+        include/BayesFilters/LinearMeasurementModel.h
         include/BayesFilters/LinearModel.h
         include/BayesFilters/LinearStateModel.h
         include/BayesFilters/LTIStateModel.h
@@ -88,6 +89,7 @@ set(${LIBRARY_TARGET_NAME}_FF_SRC
         src/DrawParticles.cpp
         src/GaussianLikelihood.cpp
         src/InitSurveillanceAreaGrid.cpp
+        src/LinearMeasurementModel.cpp
         src/LinearModel.cpp
         src/LinearStateModel.cpp
         src/LTIStateModel.cpp

--- a/src/BayesFilters/CMakeLists.txt
+++ b/src/BayesFilters/CMakeLists.txt
@@ -14,6 +14,7 @@ set(${LIBRARY_TARGET_NAME}_FA_HDR
 )
 
 set(${LIBRARY_TARGET_NAME}_FF_HDR
+        include/BayesFilters/AdditiveStateModel.h
         include/BayesFilters/Agent.h
         include/BayesFilters/AuxiliaryFunction.h
         include/BayesFilters/DrawParticles.h
@@ -79,6 +80,7 @@ set(${LIBRARY_TARGET_NAME}_FA_SRC
 )
 
 set(${LIBRARY_TARGET_NAME}_FF_SRC
+        src/AdditiveStateModel.cpp
         src/Agent.cpp
         src/AuxiliaryFunction.cpp
         src/DrawParticles.cpp

--- a/src/BayesFilters/CMakeLists.txt
+++ b/src/BayesFilters/CMakeLists.txt
@@ -97,6 +97,7 @@ set(${LIBRARY_TARGET_NAME}_FF_SRC
         src/SimulatedStateModel.cpp
         src/SPCorrection.cpp
         src/SPPrediction.cpp
+        src/StateModel.cpp
         src/StateModelDecorator.cpp
         src/UpdateParticles.cpp
         src/UKFCorrection.cpp

--- a/src/BayesFilters/include/BayesFilters/AdditiveStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/AdditiveStateModel.h
@@ -1,0 +1,24 @@
+#ifndef ADDITIVESTATEMODEL_H
+#define ADDITIVESTATEMODEL_H
+
+#include <Eigen/Dense>
+
+#include <BayesFilters/StateModel.h>
+
+namespace bfl {
+    class AdditiveStateModel;
+}
+
+
+class bfl::AdditiveStateModel : public bfl::StateModel
+{
+public:
+    virtual ~AdditiveStateModel() noexcept { };
+
+    virtual void motion(const Eigen::Ref<const Eigen::MatrixXf>& cur_states,
+                        Eigen::Ref<Eigen::MatrixXf> mot_states) override;
+
+    virtual Eigen::MatrixXf getNoiseCovarianceMatrix() = 0;
+};
+
+#endif /* ADDITIVESTATEMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/AdditiveStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/AdditiveStateModel.h
@@ -19,6 +19,8 @@ public:
                         Eigen::Ref<Eigen::MatrixXf> mot_states) override;
 
     virtual Eigen::MatrixXf getNoiseCovarianceMatrix() = 0;
+
+    virtual Eigen::MatrixXf getNoiseSample(const std::size_t num) = 0;
 };
 
 #endif /* ADDITIVESTATEMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/AdditiveStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/AdditiveStateModel.h
@@ -15,8 +15,7 @@ class bfl::AdditiveStateModel : public bfl::StateModel
 public:
     virtual ~AdditiveStateModel() noexcept { };
 
-    virtual void motion(const Eigen::Ref<const Eigen::MatrixXf>& cur_states,
-                        Eigen::Ref<Eigen::MatrixXf> mot_states) override;
+    virtual void motion(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> mot_states) override;
 
     virtual Eigen::MatrixXf getNoiseCovarianceMatrix() = 0;
 

--- a/src/BayesFilters/include/BayesFilters/LTIMeasurementModel.h
+++ b/src/BayesFilters/include/BayesFilters/LTIMeasurementModel.h
@@ -13,7 +13,7 @@ namespace bfl {
 class bfl::LTIMeasurementModel : public bfl::LinearMeasurementModel
 {
 public:
-    LTIMeasurementModel(const Eigen::MatrixXf& measurement_matrix, const Eigen::MatrixXf& noise_covariance_matrix);
+    LTIMeasurementModel(const Eigen::Ref<const Eigen::MatrixXf>& measurement_matrix, const Eigen::Ref<const Eigen::MatrixXf>& noise_covariance_matrix);
 
     virtual ~LTIMeasurementModel() noexcept { };
 

--- a/src/BayesFilters/include/BayesFilters/LTIMeasurementModel.h
+++ b/src/BayesFilters/include/BayesFilters/LTIMeasurementModel.h
@@ -1,0 +1,32 @@
+#ifndef LTIMEMEASUREMENTMODEL_H
+#define LTIMEMEASUREMENTMODEL_H
+
+#include <BayesFilters/LinearMeasurementModel.h>
+
+#include <Eigen/Dense>
+
+namespace bfl {
+    class LTIMeasurementModel;
+}
+
+
+class bfl::LTIMeasurementModel : public bfl::LinearMeasurementModel
+{
+public:
+    LTIMeasurementModel(const Eigen::MatrixXf& measurement_matrix, const Eigen::MatrixXf& noise_covariance_matrix);
+
+    virtual ~LTIMeasurementModel() noexcept { };
+
+    std::pair<bool, Eigen::MatrixXf> getNoiseCovarianceMatrix() const override;
+
+    Eigen::MatrixXf getMeasurementMatrix() const override;
+
+protected:
+    /* Measurement matrix. */
+    Eigen::MatrixXf H_;
+
+    /* Matrix covariance of the zero mean additive white measurement noise. */
+    Eigen::MatrixXf R_;
+};
+
+#endif /* LTIMEMEASUREMENTMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/LTIStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/LTIStateModel.h
@@ -13,8 +13,8 @@ namespace bfl {
 class bfl::LTIStateModel : public bfl::LinearStateModel
 {
 public:
-    LTIStateModel(Eigen::MatrixXf& transition_matrix,
-                  Eigen::MatrixXf& noise_covariance_matrix);
+    LTIStateModel(const Eigen::Ref<const Eigen::MatrixXf>& transition_matrix,
+                  const Eigen::Ref<const Eigen::MatrixXf>& noise_covariance_matrix);
 
     virtual ~LTIStateModel() noexcept { };
 

--- a/src/BayesFilters/include/BayesFilters/LTIStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/LTIStateModel.h
@@ -19,7 +19,7 @@ public:
     virtual ~LTIStateModel() noexcept { };
 
     void propagate(const Eigen::Ref<const Eigen::MatrixXf>& cur_states,
-                           Eigen::Ref<Eigen::MatrixXf> prop_states) override;
+                   Eigen::Ref<Eigen::MatrixXf> prop_states) override;
 
     Eigen::MatrixXf getNoiseCovarianceMatrix() override;
 

--- a/src/BayesFilters/include/BayesFilters/LTIStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/LTIStateModel.h
@@ -1,0 +1,44 @@
+#ifndef LTISTATEMODEL_H
+#define LTISTATEMODEL_H
+
+#include <Eigen/Dense>
+
+#include <BayesFilters/LinearStateModel.h>
+
+namespace bfl {
+    class LTIStateModel;
+}
+
+
+class bfl::LTIStateModel : public bfl::LinearStateModel
+{
+public:
+    LTIStateModel(Eigen::MatrixXf& transition_matrix,
+                  Eigen::MatrixXf& noise_covariance_matrix);
+
+    virtual ~LTIStateModel() noexcept { };
+
+    void propagate(const Eigen::Ref<const Eigen::MatrixXf>& cur_states,
+                           Eigen::Ref<Eigen::MatrixXf> prop_states) override;
+
+    Eigen::MatrixXf getNoiseCovarianceMatrix() override;
+
+    Eigen::MatrixXf getStateTransitionMatrix() override;
+
+    bool setProperty(const std::string& property) override;
+
+    Eigen::MatrixXf getJacobian() override;
+
+protected:
+    /*
+     * State transition matrix.
+     */
+    Eigen::MatrixXf F_;
+
+    /*
+     * Noise covariance matrix of zero mean additive white noise.
+     */
+    Eigen::MatrixXf Q_;
+};
+
+#endif /* LTISTATEMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/LTIStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/LTIStateModel.h
@@ -13,13 +13,11 @@ namespace bfl {
 class bfl::LTIStateModel : public bfl::LinearStateModel
 {
 public:
-    LTIStateModel(const Eigen::Ref<const Eigen::MatrixXf>& transition_matrix,
-                  const Eigen::Ref<const Eigen::MatrixXf>& noise_covariance_matrix);
+    LTIStateModel(const Eigen::Ref<const Eigen::MatrixXf>& transition_matrix, const Eigen::Ref<const Eigen::MatrixXf>& noise_covariance_matrix);
 
     virtual ~LTIStateModel() noexcept { };
 
-    void propagate(const Eigen::Ref<const Eigen::MatrixXf>& cur_states,
-                   Eigen::Ref<Eigen::MatrixXf> prop_states) override;
+    void propagate(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> prop_states) override;
 
     Eigen::MatrixXf getNoiseCovarianceMatrix() override;
 

--- a/src/BayesFilters/include/BayesFilters/LinearMeasurementModel.h
+++ b/src/BayesFilters/include/BayesFilters/LinearMeasurementModel.h
@@ -1,0 +1,25 @@
+#ifndef LINEARMEMEASUREMENTMODEL_H
+#define LINEARMEMEASUREMENTMODEL_H
+
+#include <BayesFilters/MeasurementModel.h>
+
+#include <Eigen/Dense>
+
+namespace bfl {
+    class LinearMeasurementModel;
+}
+
+
+class bfl::LinearMeasurementModel : public MeasurementModel
+{
+public:
+    virtual ~LinearMeasurementModel() noexcept { };
+
+    virtual Eigen::MatrixXf getMeasurementMatrix() const = 0;
+
+    virtual std::pair<bool, bfl::Data> predictedMeasure(const Eigen::Ref<const Eigen::MatrixXf>& cur_states) const override;
+
+    virtual std::pair<bool, bfl::Data> innovation(const bfl::Data& predicted_measurements, const bfl::Data& measurements) const override;
+};
+
+#endif /* LINEARMEMEASUREMENTMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/LinearModel.h
+++ b/src/BayesFilters/include/BayesFilters/LinearModel.h
@@ -1,7 +1,7 @@
 #ifndef LINEARMODEL_H
 #define LINEARMODEL_H
 
-#include <BayesFilters/MeasurementModel.h>
+#include <BayesFilters/LinearMeasurementModel.h>
 
 #include <fstream>
 #include <functional>
@@ -13,7 +13,7 @@ namespace bfl {
 }
 
 
-class bfl::LinearModel : public MeasurementModel
+class bfl::LinearModel : public LinearMeasurementModel
 {
 public:
     LinearModel(const float sigma_x, const float sigma_y, const unsigned int seed) noexcept;
@@ -32,13 +32,11 @@ public:
 
     LinearModel& operator=(LinearModel&& lin_sense) noexcept;
 
-    std::pair<bool, bfl::Data> predictedMeasure(const Eigen::Ref<const Eigen::MatrixXf>& cur_states) const override;
-
-    std::pair<bool, bfl::Data> innovation(const bfl::Data& predicted_measurements, const bfl::Data& measurements) const override;
-
     std::pair<bool, Eigen::MatrixXf> getNoiseSample(const int num) const;
 
     std::pair<bool, Eigen::MatrixXf> getNoiseCovarianceMatrix() const override;
+
+    Eigen::MatrixXf getMeasurementMatrix() const override;
 
 private:
     std::mt19937_64 generator_;

--- a/src/BayesFilters/include/BayesFilters/LinearModel.h
+++ b/src/BayesFilters/include/BayesFilters/LinearModel.h
@@ -32,8 +32,6 @@ public:
 
     LinearModel& operator=(LinearModel&& lin_sense) noexcept;
 
-    std::pair<bool, Eigen::MatrixXf> getNoiseSample(const int num) const;
-
     std::pair<bool, Eigen::MatrixXf> getNoiseCovarianceMatrix() const override;
 
     Eigen::MatrixXf getMeasurementMatrix() const override;
@@ -48,6 +46,8 @@ private:
     mutable std::ofstream log_file_measurements_;
 
 protected:
+    std::pair<bool, Eigen::MatrixXf> getNoiseSample(const int num) const;
+    
     /**
      * The Sampling interval in [time].
      */

--- a/src/BayesFilters/include/BayesFilters/LinearModel.h
+++ b/src/BayesFilters/include/BayesFilters/LinearModel.h
@@ -32,8 +32,6 @@ public:
 
     LinearModel& operator=(LinearModel&& lin_sense) noexcept;
 
-    std::pair<bool, bfl::Data> measure(const Eigen::Ref<const Eigen::MatrixXf>& cur_states) const override;
-
     std::pair<bool, bfl::Data> predictedMeasure(const Eigen::Ref<const Eigen::MatrixXf>& cur_states) const override;
 
     std::pair<bool, bfl::Data> innovation(const bfl::Data& predicted_measurements, const bfl::Data& measurements) const override;

--- a/src/BayesFilters/include/BayesFilters/LinearModel.h
+++ b/src/BayesFilters/include/BayesFilters/LinearModel.h
@@ -38,7 +38,7 @@ public:
 
     std::pair<bool, bfl::Data> innovation(const bfl::Data& predicted_measurements, const bfl::Data& measurements) const override;
 
-    std::pair<bool, Eigen::MatrixXf> getNoiseSample(const int num) const override;
+    std::pair<bool, Eigen::MatrixXf> getNoiseSample(const int num) const;
 
     std::pair<bool, Eigen::MatrixXf> getNoiseCovarianceMatrix() const override;
 

--- a/src/BayesFilters/include/BayesFilters/LinearStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/LinearStateModel.h
@@ -1,0 +1,23 @@
+#ifndef LINEARSTATEMODEL_H
+#define LINEARSTATEMODEL_H
+
+#include <Eigen/Dense>
+
+#include <BayesFilters/AdditiveStateModel.h>
+
+namespace bfl {
+    class LinearStateModel;
+}
+
+
+class bfl::LinearStateModel : public bfl::AdditiveStateModel
+{
+public:
+    virtual ~LinearStateModel() noexcept { };
+
+    virtual void propagate(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> mot_states) override;
+
+    virtual Eigen::MatrixXf getStateTransitionMatrix() = 0;
+};
+
+#endif /* LINEARSTATEMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/MeasurementModel.h
+++ b/src/BayesFilters/include/BayesFilters/MeasurementModel.h
@@ -30,7 +30,7 @@ public:
 
     virtual bool setProperty(const std::string& property);
 
-    virtual bool bufferAgentData() const = 0;
+    virtual bool freezeMeasurements() = 0;
 };
 
 #endif /* MEASUREMENTMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/MeasurementModel.h
+++ b/src/BayesFilters/include/BayesFilters/MeasurementModel.h
@@ -26,8 +26,6 @@ public:
 
     virtual std::pair<bool, bfl::Data> innovation(const bfl::Data& predicted_measurements, const bfl::Data& measurements) const = 0;
 
-    virtual std::pair<bool, Eigen::MatrixXf> getNoiseSample(const int num) const;
-
     virtual std::pair<bool, Eigen::MatrixXf> getNoiseCovarianceMatrix() const;
 
     virtual bool setProperty(const std::string& property);

--- a/src/BayesFilters/include/BayesFilters/MeasurementModel.h
+++ b/src/BayesFilters/include/BayesFilters/MeasurementModel.h
@@ -20,7 +20,7 @@ class bfl::MeasurementModel : public Logger
 public:
     virtual ~MeasurementModel() noexcept;
 
-    virtual std::pair<bool, bfl::Data> measure(const Eigen::Ref<const Eigen::MatrixXf>& cur_states) const = 0;
+    virtual std::pair<bool, bfl::Data> measure() const = 0;
 
     virtual std::pair<bool, bfl::Data> predictedMeasure(const Eigen::Ref<const Eigen::MatrixXf>& cur_states) const = 0;
 
@@ -31,8 +31,6 @@ public:
     virtual bool setProperty(const std::string& property);
 
     virtual bool bufferAgentData() const = 0;
-
-    virtual std::pair<bool, bfl::Data> getAgentMeasurements() const = 0;
 };
 
 #endif /* MEASUREMENTMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/MeasurementModelDecorator.h
+++ b/src/BayesFilters/include/BayesFilters/MeasurementModelDecorator.h
@@ -23,7 +23,7 @@ public:
 
     bool setProperty(const std::string& property) override;
 
-    bool bufferAgentData() const override;
+    bool freezeMeasurements() override;
 
 protected:
     MeasurementModelDecorator(std::unique_ptr<MeasurementModel> measurement_model) noexcept;

--- a/src/BayesFilters/include/BayesFilters/MeasurementModelDecorator.h
+++ b/src/BayesFilters/include/BayesFilters/MeasurementModelDecorator.h
@@ -19,8 +19,6 @@ public:
 
     std::pair<bool, bfl::Data> innovation(const bfl::Data& predicted_measurements, const bfl::Data& measurements) const override;
 
-    std::pair<bool, Eigen::MatrixXf> getNoiseSample(const int num) const override;
-
     std::pair<bool, Eigen::MatrixXf> getNoiseCovarianceMatrix() const override;
 
     bool setProperty(const std::string& property) override;

--- a/src/BayesFilters/include/BayesFilters/MeasurementModelDecorator.h
+++ b/src/BayesFilters/include/BayesFilters/MeasurementModelDecorator.h
@@ -13,7 +13,7 @@ namespace bfl {
 class bfl::MeasurementModelDecorator : public MeasurementModel
 {
 public:
-    std::pair<bool, bfl::Data> measure(const Eigen::Ref<const Eigen::MatrixXf>& cur_states) const override;
+    std::pair<bool, bfl::Data> measure() const override;
 
     std::pair<bool, bfl::Data> predictedMeasure(const Eigen::Ref<const Eigen::MatrixXf>& cur_states) const override;
 
@@ -24,8 +24,6 @@ public:
     bool setProperty(const std::string& property) override;
 
     bool bufferAgentData() const override;
-
-    std::pair<bool, bfl::Data> getAgentMeasurements() const override;
 
 protected:
     MeasurementModelDecorator(std::unique_ptr<MeasurementModel> measurement_model) noexcept;

--- a/src/BayesFilters/include/BayesFilters/SimulatedLinearSensor.h
+++ b/src/BayesFilters/include/BayesFilters/SimulatedLinearSensor.h
@@ -24,7 +24,7 @@ public:
 
     bool bufferAgentData() const override;
 
-    std::pair<bool, bfl::Data> getAgentMeasurements() const override;
+    std::pair<bool, bfl::Data> measure() const override;
 
 protected:
     std::unique_ptr<bfl::SimulatedStateModel> simulated_state_model_;

--- a/src/BayesFilters/include/BayesFilters/SimulatedLinearSensor.h
+++ b/src/BayesFilters/include/BayesFilters/SimulatedLinearSensor.h
@@ -28,6 +28,8 @@ public:
 
 protected:
     std::unique_ptr<bfl::SimulatedStateModel> simulated_state_model_;
+
+    Eigen::MatrixXf measurement_;
 };
 
 #endif /* SIMULATEDLINEARSENSOR_H */

--- a/src/BayesFilters/include/BayesFilters/SimulatedLinearSensor.h
+++ b/src/BayesFilters/include/BayesFilters/SimulatedLinearSensor.h
@@ -22,7 +22,7 @@ public:
 
     virtual ~SimulatedLinearSensor() noexcept;
 
-    bool bufferAgentData() const override;
+    bool freezeMeasurements() override;
 
     std::pair<bool, bfl::Data> measure() const override;
 

--- a/src/BayesFilters/include/BayesFilters/SimulatedStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/SimulatedStateModel.h
@@ -16,9 +16,7 @@ namespace bfl {
 class bfl::SimulatedStateModel : public Agent, public Logger
 {
 public:
-    SimulatedStateModel(std::unique_ptr<StateModel> state_model,
-                        const Eigen::Ref<const Eigen::VectorXf>& initial_state,
-                        const unsigned int simulation_time);
+    SimulatedStateModel(std::unique_ptr<StateModel> state_model, const Eigen::Ref<const Eigen::VectorXf>& initial_state, const unsigned int simulation_time);
 
     virtual ~SimulatedStateModel() noexcept;
 

--- a/src/BayesFilters/include/BayesFilters/SimulatedStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/SimulatedStateModel.h
@@ -17,7 +17,7 @@ class bfl::SimulatedStateModel : public Agent, public Logger
 {
 public:
     SimulatedStateModel(std::unique_ptr<StateModel> state_model,
-                        const Eigen::Ref<const Eigen::Vector4f>& initial_state,
+                        const Eigen::Ref<const Eigen::VectorXf>& initial_state,
                         const unsigned int simulation_time);
 
     virtual ~SimulatedStateModel() noexcept;

--- a/src/BayesFilters/include/BayesFilters/StateModel.h
+++ b/src/BayesFilters/include/BayesFilters/StateModel.h
@@ -17,8 +17,6 @@ public:
 
     virtual void motion(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> mot_states) = 0;
 
-    virtual Eigen::MatrixXf getNoiseCovarianceMatrix() = 0;
-
     virtual bool setProperty(const std::string& property) = 0;
 };
 

--- a/src/BayesFilters/include/BayesFilters/StateModel.h
+++ b/src/BayesFilters/include/BayesFilters/StateModel.h
@@ -19,6 +19,8 @@ public:
 
     virtual Eigen::MatrixXf getJacobian();
 
+    virtual Eigen::VectorXf transitionProbability(const Eigen::Ref<const Eigen::MatrixXf>& prev_states, Eigen::Ref<Eigen::MatrixXf> cur_states);
+
     virtual bool setProperty(const std::string& property) = 0;
 };
 

--- a/src/BayesFilters/include/BayesFilters/StateModel.h
+++ b/src/BayesFilters/include/BayesFilters/StateModel.h
@@ -19,7 +19,7 @@ public:
 
     virtual Eigen::MatrixXf getJacobian();
 
-    virtual Eigen::VectorXf transitionProbability(const Eigen::Ref<const Eigen::MatrixXf>& prev_states, Eigen::Ref<Eigen::MatrixXf> cur_states);
+    virtual Eigen::VectorXf getTransitionProbability(const Eigen::Ref<const Eigen::MatrixXf>& prev_states, Eigen::Ref<Eigen::MatrixXf> cur_states);
 
     virtual bool setProperty(const std::string& property) = 0;
 };

--- a/src/BayesFilters/include/BayesFilters/StateModel.h
+++ b/src/BayesFilters/include/BayesFilters/StateModel.h
@@ -17,8 +17,6 @@ public:
 
     virtual void motion(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> mot_states) = 0;
 
-    virtual Eigen::MatrixXf getNoiseSample(const int num) = 0;
-
     virtual Eigen::MatrixXf getNoiseCovarianceMatrix() = 0;
 
     virtual bool setProperty(const std::string& property) = 0;

--- a/src/BayesFilters/include/BayesFilters/StateModel.h
+++ b/src/BayesFilters/include/BayesFilters/StateModel.h
@@ -17,6 +17,8 @@ public:
 
     virtual void motion(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> mot_states) = 0;
 
+    virtual Eigen::MatrixXf getJacobian();
+
     virtual bool setProperty(const std::string& property) = 0;
 };
 

--- a/src/BayesFilters/include/BayesFilters/StateModelDecorator.h
+++ b/src/BayesFilters/include/BayesFilters/StateModelDecorator.h
@@ -17,8 +17,6 @@ public:
 
     void motion(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> mot_states) override;
 
-    Eigen::MatrixXf getNoiseCovarianceMatrix() override;
-
     bool setProperty(const std::string& property) override;
 
 protected:

--- a/src/BayesFilters/include/BayesFilters/StateModelDecorator.h
+++ b/src/BayesFilters/include/BayesFilters/StateModelDecorator.h
@@ -17,8 +17,6 @@ public:
 
     void motion(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> mot_states) override;
 
-    Eigen::MatrixXf getNoiseSample(const int num) override;
-
     Eigen::MatrixXf getNoiseCovarianceMatrix() override;
 
     bool setProperty(const std::string& property) override;

--- a/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
+++ b/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
@@ -30,8 +30,6 @@ public:
 
     WhiteNoiseAcceleration& operator=(WhiteNoiseAcceleration&& wna) noexcept;
 
-    void motion(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> prop_states) override;
-
     Eigen::MatrixXf getNoiseSample(const int num);
 
     Eigen::MatrixXf getNoiseCovarianceMatrix() override;

--- a/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
+++ b/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
@@ -36,7 +36,7 @@ public:
 
     Eigen::MatrixXf getNoiseSample(const int num);
 
-    Eigen::MatrixXf getNoiseCovarianceMatrix() override;
+    Eigen::MatrixXf getNoiseCovarianceMatrix();
 
     bool setProperty(const std::string& property) override { return false; };
 

--- a/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
+++ b/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
@@ -30,7 +30,7 @@ public:
 
     WhiteNoiseAcceleration& operator=(WhiteNoiseAcceleration&& wna) noexcept;
 
-    Eigen::MatrixXf getNoiseSample(const int num) override;
+    Eigen::MatrixXf getNoiseSample(const std::size_t num) override;
 
     Eigen::MatrixXf getNoiseCovarianceMatrix() override;
 

--- a/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
+++ b/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
@@ -1,7 +1,7 @@
 #ifndef WHITENOISEACCELERATION_H
 #define WHITENOISEACCELERATION_H
 
-#include <BayesFilters/StateModel.h>
+#include <BayesFilters/LinearStateModel.h>
 
 #include <functional>
 #include <random>
@@ -11,7 +11,7 @@ namespace bfl {
 }
 
 
-class bfl::WhiteNoiseAcceleration : public StateModel
+class bfl::WhiteNoiseAcceleration : public LinearStateModel
 {
 public:
     WhiteNoiseAcceleration(float T, float tilde_q, unsigned int seed) noexcept;
@@ -30,13 +30,13 @@ public:
 
     WhiteNoiseAcceleration& operator=(WhiteNoiseAcceleration&& wna) noexcept;
 
-    void propagate(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> prop_states) override;
-
     void motion(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> prop_states) override;
 
     Eigen::MatrixXf getNoiseSample(const int num);
 
-    Eigen::MatrixXf getNoiseCovarianceMatrix();
+    Eigen::MatrixXf getNoiseCovarianceMatrix() override;
+
+    Eigen::MatrixXf getStateTransitionMatrix() override;
 
     bool setProperty(const std::string& property) override { return false; };
 

--- a/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
+++ b/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
@@ -30,7 +30,7 @@ public:
 
     WhiteNoiseAcceleration& operator=(WhiteNoiseAcceleration&& wna) noexcept;
 
-    Eigen::MatrixXf getNoiseSample(const int num);
+    Eigen::MatrixXf getNoiseSample(const int num) override;
 
     Eigen::MatrixXf getNoiseCovarianceMatrix() override;
 

--- a/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
+++ b/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
@@ -34,7 +34,7 @@ public:
 
     void motion(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> prop_states) override;
 
-    Eigen::MatrixXf getNoiseSample(const int num) override;
+    Eigen::MatrixXf getNoiseSample(const int num);
 
     Eigen::MatrixXf getNoiseCovarianceMatrix() override;
 

--- a/src/BayesFilters/src/AdditiveStateModel.cpp
+++ b/src/BayesFilters/src/AdditiveStateModel.cpp
@@ -5,11 +5,7 @@
 using namespace bfl;
 using namespace Eigen;
 
-void AdditiveStateModel::motion
-(
-    const Eigen::Ref<const Eigen::MatrixXf>& cur_states,
-    Eigen::Ref<Eigen::MatrixXf> mot_states
-)
+void AdditiveStateModel::motion(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> mot_states)
 {
     propagate(cur_states, mot_states);
     mot_states += getNoiseSample(mot_states.cols());

--- a/src/BayesFilters/src/AdditiveStateModel.cpp
+++ b/src/BayesFilters/src/AdditiveStateModel.cpp
@@ -1,0 +1,17 @@
+#include <BayesFilters/AdditiveStateModel.h>
+
+#include <Eigen/Dense>
+
+using namespace bfl;
+using namespace Eigen;
+
+void AdditiveStateModel::motion
+(
+    const Eigen::Ref<const Eigen::MatrixXf>& cur_states,
+    Eigen::Ref<Eigen::MatrixXf> mot_states
+)
+{
+    /* FIXME
+       Add additive noise generation. */
+    propagate(cur_states, mot_states); // + add noise
+}

--- a/src/BayesFilters/src/AdditiveStateModel.cpp
+++ b/src/BayesFilters/src/AdditiveStateModel.cpp
@@ -11,7 +11,6 @@ void AdditiveStateModel::motion
     Eigen::Ref<Eigen::MatrixXf> mot_states
 )
 {
-    /* FIXME
-       Add additive noise generation. */
-    propagate(cur_states, mot_states); // + add noise
+    propagate(cur_states, mot_states);
+    mot_states += getNoiseSample(mot_states.cols());
 }

--- a/src/BayesFilters/src/GaussianLikelihood.cpp
+++ b/src/BayesFilters/src/GaussianLikelihood.cpp
@@ -20,7 +20,7 @@ std::pair<bool, VectorXf> GaussianLikelihood::likelihood
 {
     bool valid_measurements;
     Data data_measurements;
-    std::tie(valid_measurements, data_measurements) = measurement_model.getAgentMeasurements();
+    std::tie(valid_measurements, data_measurements) = measurement_model.measure();
 
     MatrixXf measurements;
     if (valid_measurements)

--- a/src/BayesFilters/src/LTIMeasurementModel.cpp
+++ b/src/BayesFilters/src/LTIMeasurementModel.cpp
@@ -6,11 +6,8 @@ using namespace bfl;
 using namespace Eigen;
 
 
-LTIMeasurementModel::LTIMeasurementModel
-(
-    const Ref<const MatrixXf>& measurement_matrix,
-    const Ref<const MatrixXf>& noise_covariance_matrix
-) : H_(measurement_matrix), R_(noise_covariance_matrix)
+LTIMeasurementModel::LTIMeasurementModel(const Ref<const MatrixXf>& measurement_matrix, const Ref<const MatrixXf>& noise_covariance_matrix)
+    : H_(measurement_matrix), R_(noise_covariance_matrix)
 {
     if ((H_.rows() == 0) || (H_.cols() == 0))
         throw std::runtime_error("ERROR::LTIMEASUREMENTMODEL::CTOR\nERROR:\n\tMeasurement matrix dimensions cannot be 0.");

--- a/src/BayesFilters/src/LTIMeasurementModel.cpp
+++ b/src/BayesFilters/src/LTIMeasurementModel.cpp
@@ -8,8 +8,8 @@ using namespace Eigen;
 
 LTIMeasurementModel::LTIMeasurementModel
 (
-    const Eigen::MatrixXf& measurement_matrix,
-    const Eigen::MatrixXf& noise_covariance_matrix
+    const Ref<const MatrixXf>& measurement_matrix,
+    const Ref<const MatrixXf>& noise_covariance_matrix
 ) : H_(measurement_matrix), R_(noise_covariance_matrix)
 {
     if ((H_.rows() == 0) || (H_.cols() == 0))

--- a/src/BayesFilters/src/LTIMeasurementModel.cpp
+++ b/src/BayesFilters/src/LTIMeasurementModel.cpp
@@ -1,0 +1,35 @@
+#include <BayesFilters/LTIMeasurementModel.h>
+
+#include <Eigen/Dense>
+
+using namespace bfl;
+using namespace Eigen;
+
+
+LTIMeasurementModel::LTIMeasurementModel
+(
+    const Eigen::MatrixXf& measurement_matrix,
+    const Eigen::MatrixXf& noise_covariance_matrix
+) : H_(measurement_matrix), R_(noise_covariance_matrix)
+{
+    if ((H_.rows() == 0) || (H_.cols() == 0))
+        throw std::runtime_error("ERROR::LTIMEASUREMENTMODEL::CTOR\nERROR:\n\tMeasurement matrix dimensions cannot be 0.");
+    else if ((R_.rows() == 0) || (R_.cols() == 0))
+        throw std::runtime_error("ERROR::LTIMEASUREMENTMODEL::CTOR\nERROR:\n\tNoise covariance matrix dimensions cannot be 0.");
+    else if (R_.rows() != R_.cols())
+        throw std::runtime_error("ERROR::LTIMEASUREMENTMODEL::CTOR\nERROR:\n\tNoise covariance matrix must be a square matrix.");
+    else if (H_.rows() != R_.rows())
+        throw std::runtime_error("ERROR::LTIMEASUREMENTMODEL::CTOR\nERROR:\n\tNumber of rows of the measurement matrix must be the same as the size of the noise covariance matrix.");
+}
+
+
+std::pair<bool, Eigen::MatrixXf> LTIMeasurementModel::getNoiseCovarianceMatrix() const
+{
+    return std::make_pair(true, R_);
+}
+
+
+Eigen::MatrixXf LTIMeasurementModel::getMeasurementMatrix() const
+{
+    return H_;
+}

--- a/src/BayesFilters/src/LTIStateModel.cpp
+++ b/src/BayesFilters/src/LTIStateModel.cpp
@@ -1,0 +1,54 @@
+#include <BayesFilters/LTIStateModel.h>
+
+#include <Eigen/Dense>
+
+using namespace bfl;
+using namespace Eigen;
+
+
+LTIStateModel::LTIStateModel(Eigen::MatrixXf& transition_matrix,
+                             Eigen::MatrixXf& noise_covariance_matrix) :
+    F_(transition_matrix), Q_(noise_covariance_matrix)
+{
+    if ((F_.rows() == 0) || (F_.cols() == 0))
+        throw std::runtime_error("ERROR::LTISTATEMODEL::CTOR\nERROR:\n\tState transition matrix dimensions cannot be 0.");
+    else if ((Q_.rows() == 0) || (Q_.cols() == 0))
+        throw std::runtime_error("ERROR::LTISTATEMODEL::CTOR\nERROR:\n\tNoise covariance matrix dimensions cannot be 0.");
+    else if (F_.rows() != F_.cols())
+        throw std::runtime_error("ERROR::LTISTATEMODEL::CTOR\nERROR:\n\tState transition matrix must be a square matrix.");
+    else if (Q_.rows() != Q_.cols())
+        throw std::runtime_error("ERROR::LTISTATEMODEL::CTOR\nERROR:\n\tNoise covariance matrix must be a square matrix.");
+    else if (F_.rows() != Q_.rows())
+        throw std::runtime_error("ERROR::LTISTATEMODEL::CTOR\nERROR:\n\tNumber of rows of the state transition matrix must be the same as the size of the noise covariance matrix.");
+}
+
+
+void LTIStateModel::propagate(const Eigen::Ref<const Eigen::MatrixXf>& cur_states,
+                              Eigen::Ref<Eigen::MatrixXf> prop_states)
+{
+    prop_states = F_ * cur_states;
+}
+
+
+Eigen::MatrixXf LTIStateModel::getNoiseCovarianceMatrix()
+{
+    return Q_;
+}
+
+
+Eigen::MatrixXf LTIStateModel::getStateTransitionMatrix()
+{
+    return F_;
+}
+
+
+bool LTIStateModel::setProperty(const std::string& property)
+{
+    return false;
+}
+
+
+Eigen::MatrixXf LTIStateModel::getJacobian()
+{
+    return F_;
+}

--- a/src/BayesFilters/src/LTIStateModel.cpp
+++ b/src/BayesFilters/src/LTIStateModel.cpp
@@ -6,8 +6,8 @@ using namespace bfl;
 using namespace Eigen;
 
 
-LTIStateModel::LTIStateModel(Eigen::MatrixXf& transition_matrix,
-                             Eigen::MatrixXf& noise_covariance_matrix) :
+LTIStateModel::LTIStateModel(const Ref<const MatrixXf>& transition_matrix,
+                             const Ref<const MatrixXf>& noise_covariance_matrix) :
     F_(transition_matrix), Q_(noise_covariance_matrix)
 {
     if ((F_.rows() == 0) || (F_.cols() == 0))

--- a/src/BayesFilters/src/LTIStateModel.cpp
+++ b/src/BayesFilters/src/LTIStateModel.cpp
@@ -6,8 +6,7 @@ using namespace bfl;
 using namespace Eigen;
 
 
-LTIStateModel::LTIStateModel(const Ref<const MatrixXf>& transition_matrix,
-                             const Ref<const MatrixXf>& noise_covariance_matrix) :
+LTIStateModel::LTIStateModel(const Ref<const MatrixXf>& transition_matrix, const Ref<const MatrixXf>& noise_covariance_matrix) :
     F_(transition_matrix), Q_(noise_covariance_matrix)
 {
     if ((F_.rows() == 0) || (F_.cols() == 0))
@@ -23,8 +22,7 @@ LTIStateModel::LTIStateModel(const Ref<const MatrixXf>& transition_matrix,
 }
 
 
-void LTIStateModel::propagate(const Eigen::Ref<const Eigen::MatrixXf>& cur_states,
-                              Eigen::Ref<Eigen::MatrixXf> prop_states)
+void LTIStateModel::propagate(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> prop_states)
 {
     prop_states = F_ * cur_states;
 }

--- a/src/BayesFilters/src/LinearMeasurementModel.cpp
+++ b/src/BayesFilters/src/LinearMeasurementModel.cpp
@@ -13,11 +13,7 @@ std::pair<bool, bfl::Data> LinearMeasurementModel::predictedMeasure(const Eigen:
 }
 
 
-std::pair<bool, bfl::Data> LinearMeasurementModel::innovation
-(
-    const bfl::Data& predicted_measurements,
-    const bfl::Data& measurements
-) const
+std::pair<bool, bfl::Data> LinearMeasurementModel::innovation(const bfl::Data& predicted_measurements, const bfl::Data& measurements) const
 {
     MatrixXf innovation = -(any::any_cast<MatrixXf>(predicted_measurements).colwise() - any::any_cast<MatrixXf>(measurements).col(0));
 

--- a/src/BayesFilters/src/LinearMeasurementModel.cpp
+++ b/src/BayesFilters/src/LinearMeasurementModel.cpp
@@ -1,0 +1,25 @@
+#include <BayesFilters/LinearMeasurementModel.h>
+
+#include <Eigen/Dense>
+
+using namespace bfl;
+using namespace Eigen;
+
+
+std::pair<bool, bfl::Data> LinearMeasurementModel::predictedMeasure(const Eigen::Ref<const Eigen::MatrixXf>& cur_states) const
+{
+    MatrixXf prediction = getMeasurementMatrix() * cur_states;
+    return std::make_pair(true, std::move(prediction));
+}
+
+
+std::pair<bool, bfl::Data> LinearMeasurementModel::innovation
+(
+    const bfl::Data& predicted_measurements,
+    const bfl::Data& measurements
+) const
+{
+    MatrixXf innovation = -(any::any_cast<MatrixXf>(predicted_measurements).colwise() - any::any_cast<MatrixXf>(measurements).col(0));
+
+    return std::make_pair(true, std::move(innovation));
+}

--- a/src/BayesFilters/src/LinearModel.cpp
+++ b/src/BayesFilters/src/LinearModel.cpp
@@ -130,24 +130,6 @@ LinearModel& LinearModel::operator=(LinearModel&& lin_sense) noexcept
 }
 
 
-std::pair<bool, Data> LinearModel::measure(const Ref<const MatrixXf>& cur_states) const
-{
-    Data data_measurements;
-    std::tie(std::ignore, data_measurements) = predictedMeasure(cur_states);
-
-    MatrixXf measurements = any::any_cast<MatrixXf&&>(std::move(data_measurements));
-
-    MatrixXf noise;
-    std::tie(std::ignore, noise) = getNoiseSample(measurements.cols());
-
-    measurements += noise;
-
-    logger(measurements.transpose());
-
-    return std::make_pair(true, measurements);
-}
-
-
 std::pair<bool, Data> LinearModel::predictedMeasure(const Ref<const MatrixXf>& cur_states) const
 {
     MatrixXf predicted_measure = H_ * cur_states;

--- a/src/BayesFilters/src/LinearModel.cpp
+++ b/src/BayesFilters/src/LinearModel.cpp
@@ -130,22 +130,6 @@ LinearModel& LinearModel::operator=(LinearModel&& lin_sense) noexcept
 }
 
 
-std::pair<bool, Data> LinearModel::predictedMeasure(const Ref<const MatrixXf>& cur_states) const
-{
-    MatrixXf predicted_measure = H_ * cur_states;
-
-    return std::make_pair(true, std::move(predicted_measure));
-}
-
-
-std::pair<bool, Data> LinearModel::innovation(const Data& predicted_measurements, const Data& measurements) const
-{
-    MatrixXf innovation = -(any::any_cast<MatrixXf>(predicted_measurements).colwise() - any::any_cast<MatrixXf>(measurements).col(0));
-
-    return std::make_pair(true, std::move(innovation));
-}
-
-
 std::pair<bool, MatrixXf> LinearModel::getNoiseSample(const int num) const
 {
     MatrixXf rand_vectors(2, num);
@@ -161,4 +145,10 @@ std::pair<bool, MatrixXf> LinearModel::getNoiseSample(const int num) const
 std::pair<bool, MatrixXf> LinearModel::getNoiseCovarianceMatrix() const
 {
     return std::make_pair(true, R_);
+}
+
+
+Eigen::MatrixXf LinearModel::getMeasurementMatrix() const
+{
+    return H_;
 }

--- a/src/BayesFilters/src/LinearStateModel.cpp
+++ b/src/BayesFilters/src/LinearStateModel.cpp
@@ -6,11 +6,7 @@ using namespace bfl;
 using namespace Eigen;
 
 
-void LinearStateModel::propagate
-(
-    const Eigen::Ref<const Eigen::MatrixXf>& cur_states,
-    Eigen::Ref<Eigen::MatrixXf> pred_states
-)
+void LinearStateModel::propagate(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> pred_states)
 {
     pred_states = getStateTransitionMatrix() * cur_states;
 }

--- a/src/BayesFilters/src/LinearStateModel.cpp
+++ b/src/BayesFilters/src/LinearStateModel.cpp
@@ -1,0 +1,16 @@
+#include <BayesFilters/LinearStateModel.h>
+
+#include <Eigen/Dense>
+
+using namespace bfl;
+using namespace Eigen;
+
+
+void LinearStateModel::propagate
+(
+    const Eigen::Ref<const Eigen::MatrixXf>& cur_states,
+    Eigen::Ref<Eigen::MatrixXf> pred_states
+)
+{
+    pred_states = getStateTransitionMatrix() * cur_states;
+}

--- a/src/BayesFilters/src/MeasurementModel.cpp
+++ b/src/BayesFilters/src/MeasurementModel.cpp
@@ -10,12 +10,6 @@ MeasurementModel::~MeasurementModel() noexcept
 { }
 
 
-std::pair<bool, MatrixXf> MeasurementModel::getNoiseSample(const int num) const
-{
-    return std::make_pair(false, MatrixXf::Zero(1, 1));
-}
-
-
 std::pair<bool, MatrixXf> MeasurementModel::getNoiseCovarianceMatrix() const
 {
     return std::make_pair(false, MatrixXf::Zero(1, 1));

--- a/src/BayesFilters/src/MeasurementModelDecorator.cpp
+++ b/src/BayesFilters/src/MeasurementModelDecorator.cpp
@@ -53,7 +53,7 @@ bool MeasurementModelDecorator::setProperty(const std::string& property)
 }
 
 
-bool MeasurementModelDecorator::bufferAgentData() const
+bool MeasurementModelDecorator::freezeMeasurements()
 {
-    return measurement_model->bufferAgentData();
+    return measurement_model->freezeMeasurements();
 }

--- a/src/BayesFilters/src/MeasurementModelDecorator.cpp
+++ b/src/BayesFilters/src/MeasurementModelDecorator.cpp
@@ -23,9 +23,9 @@ MeasurementModelDecorator& MeasurementModelDecorator::operator=(MeasurementModel
 }
 
 
-std::pair<bool, Data> MeasurementModelDecorator::measure(const Ref<const MatrixXf>& cur_states) const
+std::pair<bool, Data> MeasurementModelDecorator::measure() const
 {
-    return measurement_model->measure(cur_states);
+    return measurement_model->measure();
 }
 
 
@@ -56,10 +56,4 @@ bool MeasurementModelDecorator::setProperty(const std::string& property)
 bool MeasurementModelDecorator::bufferAgentData() const
 {
     return measurement_model->bufferAgentData();
-}
-
-
-std::pair<bool, Data> MeasurementModelDecorator::getAgentMeasurements() const
-{
-    return measurement_model->getAgentMeasurements();
 }

--- a/src/BayesFilters/src/MeasurementModelDecorator.cpp
+++ b/src/BayesFilters/src/MeasurementModelDecorator.cpp
@@ -41,12 +41,6 @@ std::pair<bool, Data> MeasurementModelDecorator::innovation(const Data& predicte
 }
 
 
-std::pair<bool, MatrixXf> MeasurementModelDecorator::getNoiseSample(const int num) const
-{
-    return measurement_model->getNoiseSample(num);
-}
-
-
 std::pair<bool, MatrixXf> MeasurementModelDecorator::getNoiseCovarianceMatrix() const
 {
     return measurement_model->getNoiseCovarianceMatrix();

--- a/src/BayesFilters/src/SimulatedLinearSensor.cpp
+++ b/src/BayesFilters/src/SimulatedLinearSensor.cpp
@@ -43,9 +43,16 @@ bool SimulatedLinearSensor::bufferAgentData() const
 }
 
 
-std::pair<bool, Data> SimulatedLinearSensor::getAgentMeasurements() const
+std::pair<bool, Data> SimulatedLinearSensor::measure() const
 {
-    MatrixXf simulated_state = any::any_cast<MatrixXf>(simulated_state_model_->getData());
+    MatrixXf measurements = H_ * any::any_cast<MatrixXf>(simulated_state_model_->getData());
 
-    return measure(simulated_state);
+    MatrixXf noise;
+    std::tie(std::ignore, noise) = getNoiseSample(measurements.cols());
+
+    measurements += noise;
+
+    logger(measurements.transpose());
+
+    return std::make_pair(true, measurements);
 }

--- a/src/BayesFilters/src/SimulatedLinearSensor.cpp
+++ b/src/BayesFilters/src/SimulatedLinearSensor.cpp
@@ -37,7 +37,7 @@ SimulatedLinearSensor::~SimulatedLinearSensor() noexcept
 { }
 
 
-bool SimulatedLinearSensor::bufferAgentData() const
+bool SimulatedLinearSensor::freezeMeasurements()
 {
     return simulated_state_model_->bufferData();
 }

--- a/src/BayesFilters/src/SimulatedStateModel.cpp
+++ b/src/BayesFilters/src/SimulatedStateModel.cpp
@@ -9,13 +9,13 @@ using namespace Eigen;
 SimulatedStateModel::SimulatedStateModel
 (
     std::unique_ptr<StateModel> state_model,
-    const Ref<const Vector4f>& initial_state,
+    const Ref<const VectorXf>& initial_state,
     const unsigned int simulation_time
 ) :
     simulation_time_(simulation_time),
     state_model_(std::move(state_model))
 {
-    target_ = MatrixXf(4, simulation_time_);
+    target_ = MatrixXf(initial_state.rows(), simulation_time_);
     target_.col(0) = initial_state;
 
     for (int k = 1; k < simulation_time_; ++k)

--- a/src/BayesFilters/src/StateModel.cpp
+++ b/src/BayesFilters/src/StateModel.cpp
@@ -10,7 +10,7 @@ Eigen::MatrixXf StateModel::getJacobian()
 }
 
 
-Eigen::VectorXf StateModel::transitionProbability(const Eigen::Ref<const Eigen::MatrixXf>& prev_states, Eigen::Ref<Eigen::MatrixXf> cur_states)
+Eigen::VectorXf StateModel::getTransitionProbability(const Eigen::Ref<const Eigen::MatrixXf>& prev_states, Eigen::Ref<Eigen::MatrixXf> cur_states)
 {
     throw std::runtime_error("ERROR::STATEMODEL::TRANSITIONPROBABILITY\nERROR:\n\tMethod not implemented.");
 }

--- a/src/BayesFilters/src/StateModel.cpp
+++ b/src/BayesFilters/src/StateModel.cpp
@@ -8,3 +8,9 @@ Eigen::MatrixXf StateModel::getJacobian()
 {
     throw std::runtime_error("ERROR::STATEMODEL::GETJACOBIAN\nERROR:\n\tMethod not implemented.");
 }
+
+
+Eigen::VectorXf StateModel::transitionProbability(const Eigen::Ref<const Eigen::MatrixXf>& prev_states, Eigen::Ref<Eigen::MatrixXf> cur_states)
+{
+    throw std::runtime_error("ERROR::STATEMODEL::TRANSITIONPROBABILITY\nERROR:\n\tMethod not implemented.");
+}

--- a/src/BayesFilters/src/StateModel.cpp
+++ b/src/BayesFilters/src/StateModel.cpp
@@ -1,0 +1,10 @@
+#include <BayesFilters/StateModel.h>
+
+using namespace bfl;
+using namespace Eigen;
+
+
+Eigen::MatrixXf StateModel::getJacobian()
+{
+    throw std::runtime_error("ERROR::STATEMODEL::GETJACOBIAN\nERROR:\n\tMethod not implemented.");
+}

--- a/src/BayesFilters/src/StateModelDecorator.cpp
+++ b/src/BayesFilters/src/StateModelDecorator.cpp
@@ -35,12 +35,6 @@ void StateModelDecorator::motion(const Ref<const MatrixXf>& cur_states, Ref<Matr
 }
 
 
-MatrixXf StateModelDecorator::getNoiseSample(const int num)
-{
-    return state_model_->getNoiseSample(num);
-}
-
-
 MatrixXf StateModelDecorator::getNoiseCovarianceMatrix()
 {
     return state_model_->getNoiseCovarianceMatrix();

--- a/src/BayesFilters/src/StateModelDecorator.cpp
+++ b/src/BayesFilters/src/StateModelDecorator.cpp
@@ -35,12 +35,6 @@ void StateModelDecorator::motion(const Ref<const MatrixXf>& cur_states, Ref<Matr
 }
 
 
-MatrixXf StateModelDecorator::getNoiseCovarianceMatrix()
-{
-    return state_model_->getNoiseCovarianceMatrix();
-}
-
-
 bool StateModelDecorator::setProperty(const std::string& property)
 {
     return state_model_->setProperty(property);

--- a/src/BayesFilters/src/UpdateParticles.cpp
+++ b/src/BayesFilters/src/UpdateParticles.cpp
@@ -15,9 +15,9 @@ UpdateParticles::~UpdateParticles() noexcept { }
 
 void UpdateParticles::correctStep(const ParticleSet& pred_particles, ParticleSet& cor_particles)
 {
-    bool valid_buffered_agent_data = measurement_model_->bufferAgentData();
+    bool valid_freeze = measurement_model_->freezeMeasurements();
 
-    if (valid_buffered_agent_data)
+    if (valid_freeze)
         std::tie(valid_likelihood_, likelihood_) = likelihood_model_->likelihood(*measurement_model_,
                                                                                  pred_particles.state().cast<float>());
     cor_particles = pred_particles;

--- a/src/BayesFilters/src/WhiteNoiseAcceleration.cpp
+++ b/src/BayesFilters/src/WhiteNoiseAcceleration.cpp
@@ -108,7 +108,7 @@ WhiteNoiseAcceleration& WhiteNoiseAcceleration::operator=(WhiteNoiseAcceleration
 }
 
 
-MatrixXf WhiteNoiseAcceleration::getNoiseSample(const int num)
+MatrixXf WhiteNoiseAcceleration::getNoiseSample(const std::size_t num)
 {
     MatrixXf rand_vectors(4, num);
     for (int i = 0; i < rand_vectors.size(); i++)

--- a/src/BayesFilters/src/WhiteNoiseAcceleration.cpp
+++ b/src/BayesFilters/src/WhiteNoiseAcceleration.cpp
@@ -108,14 +108,6 @@ WhiteNoiseAcceleration& WhiteNoiseAcceleration::operator=(WhiteNoiseAcceleration
 }
 
 
-void WhiteNoiseAcceleration::motion(const Ref<const MatrixXf>& cur_states, Ref<MatrixXf> prop_states)
-{
-    propagate(cur_states, prop_states);
-
-    prop_states += getNoiseSample(prop_states.cols());
-}
-
-
 MatrixXf WhiteNoiseAcceleration::getNoiseSample(const int num)
 {
     MatrixXf rand_vectors(4, num);

--- a/src/BayesFilters/src/WhiteNoiseAcceleration.cpp
+++ b/src/BayesFilters/src/WhiteNoiseAcceleration.cpp
@@ -108,12 +108,6 @@ WhiteNoiseAcceleration& WhiteNoiseAcceleration::operator=(WhiteNoiseAcceleration
 }
 
 
-void WhiteNoiseAcceleration::propagate(const Ref<const MatrixXf>& cur_states, Ref<MatrixXf> prop_states)
-{
-    prop_states = F_ * cur_states;
-}
-
-
 void WhiteNoiseAcceleration::motion(const Ref<const MatrixXf>& cur_states, Ref<MatrixXf> prop_states)
 {
     propagate(cur_states, prop_states);
@@ -135,4 +129,10 @@ MatrixXf WhiteNoiseAcceleration::getNoiseSample(const int num)
 MatrixXf WhiteNoiseAcceleration::getNoiseCovarianceMatrix()
 {
     return Q_;
+}
+
+
+MatrixXf WhiteNoiseAcceleration::getStateTransitionMatrix()
+{
+    return F_;
 }

--- a/test/test_SIS_Decorators/main.cpp
+++ b/test/test_SIS_Decorators/main.cpp
@@ -50,11 +50,11 @@ public:
     { }
 
 
-    std::pair<bool, bfl::Data> measure(const Eigen::Ref<const Eigen::MatrixXf>& cur_states) const override
+    std::pair<bool, bfl::Data> measure() const override
     {
         std::cout << "Decorator: DecoratedLinearSensor::measure()." << std::endl;
 
-        return MeasurementModelDecorator::measure(cur_states);
+        return MeasurementModelDecorator::measure();
     }
 };
 


### PR DESCRIPTION
### Within this PR:
#### State models
- New hierarchy for state models:
   - `StateModel` represents a generic `x_k = f(x_{k-1}, u_{k-1}, w_{k-1})`
   - Implemented `AdditiveStateModel` representing `x_k = f(x_{k-1}, u_{k-1}) + w_{k-1}` with `w` white Gaussian noise
   - Implemented `LinearStateModel` inheriting from `AdditiveStateModel`, representing `x_k = F_{k-1} x_{k-1} + w_{k-1}`
   - Implemented `LTIStateModel` inheriting from `LinearStateModel`, representing `x_k = F x_{k-1} + w_{k-1}`
- Removed `StateModel` methods `getNoiseCovarianceMatrix` and `getNoiseSample`
- Added non-pure virtual `StateModel` methods `getJacobian` and `transitionProability`
- Class `WhiteNoiseAcceleration` now inherits from `LinearStateModel`
- Class `SimulatedStateModel` now supports state vectors of any size (before was 4)

#### Measurement models
- New hierarchy for measurement models:
  - `MeasurementModel` represents a generic `y_k = h(x_k, r_k)` with `r_k` Gaussian noise
  - Implemented `LinearMeasurementModel` inheriting from `MeasurementModel`, representing `y_k = H_k x_k + r_k`
  - Implemented `LTIMeasurementModel` inheriting from `LinearMeasurementModel`, representing `y_k = H x_k + r_k`
- Removed `MeasurementModel` method `getNoiseSample`
- Class `LinearModel` now inherits from `LinearMeasurementModel`
-  Method `MeasurementModel::measure` replaces method `MeasurementModel::getAgentMeasurements` and **does not take the state as input**
- Renamed method `MeasurementModel::bufferAgentData` to `MeasurementModel::freezeMeasurements` to better explain its meaning

After these changes `LinearSensor` looses its method `measure` that is implemented in inheriting classes. E.g., `SimulatedLinearSensor` implements `measure`.

Also, from now on it is intended that the method `measure` can be called any number of time within the same time step (there are several algorithms where this happen). For this reason the actual computation of the measurement should happen in `freezeMeasurements` while `measure` just returns the last frozen measurement. E.g., `SimulatedLinearSensor` now effectively simulate measurements in `freezeMeasurements`. 

#### Tests
- Updated test_SIS_Decorators (since use `MeasurementModelDecorator` inheriting from `MeasurementModel`)

#### Version
- Increase version to 0.9.101 since breaking API

#### Changelog
- Update CHANGELOG.md