### PR TITLE
Change behavior of PFCorrection::correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
  - Used new ParticleSet class within classes PFPrediction, PFPredictionDecorator, PFCorrection, PFCorrectionDecorator, DrawParticles, UpdateParticles, Resampling, ResamplingWithPrior, ParticleSetInitialization, InitSurveillanceAreaGrid and SIS.
  - Method ResamplingWithPrior::resample heavily changed (due to use of ParticleSet).
  - Methods Resampling::resample and ResamplingWithPrior::resample use VectorXi instead of VectorXf to represent particle parents.
+ - PFCorrection now performs measurements freeze before calling PFCorrection::correctStep and does not call it if measurements freeze fails.
+ - UpdateParticles::correctStep now does not freeze measurements anymore.
 
 ###### State models
  - Added SimulatedStateModel class to simulate kinematic or dynamic models using StateModel classes.

--- a/src/BayesFilters/src/PFCorrection.cpp
+++ b/src/BayesFilters/src/PFCorrection.cpp
@@ -9,7 +9,8 @@ PFCorrection::PFCorrection() noexcept { };
 
 void PFCorrection::correct(const ParticleSet& pred_particles, ParticleSet& cor_particles)
 {
-    if (!skip_)
+    /* Perform correction if required and if measurements can be frozen. */
+    if ((!skip_) && getMeasurementModel().freezeMeasurements())
         correctStep(pred_particles, cor_particles);
     else
         cor_particles = pred_particles;

--- a/src/BayesFilters/src/UpdateParticles.cpp
+++ b/src/BayesFilters/src/UpdateParticles.cpp
@@ -15,11 +15,8 @@ UpdateParticles::~UpdateParticles() noexcept { }
 
 void UpdateParticles::correctStep(const ParticleSet& pred_particles, ParticleSet& cor_particles)
 {
-    bool valid_freeze = measurement_model_->freezeMeasurements();
-
-    if (valid_freeze)
-        std::tie(valid_likelihood_, likelihood_) = likelihood_model_->likelihood(*measurement_model_,
-                                                                                 pred_particles.state().cast<float>());
+    std::tie(valid_likelihood_, likelihood_) = likelihood_model_->likelihood(*measurement_model_, pred_particles.state().cast<float>());
+    
     cor_particles = pred_particles;
 
     if (valid_likelihood_)


### PR DESCRIPTION
This PR changes the behavior of `PFCorrection::correct`: 

- the measurements are frozen, i.e. calling `MeasurementModel::freezeMeasurements`, before calling the method `PFCorrection::correctStep` that is implemented by inheriting classes
- the actual correction, i.e. calling `PFCorrection::correctStep`, happens only if is is requested by the user and the measurements freeze was successful