### PR TITLE
Implement unscented transform utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,9 @@
  - Added Data class in order to have a type for encapsulating data coming from any process.
  - Added GaussianMixture, Gaussian and ParticleSet classes.
  - Added directional_add(), directional_sub() and directional_mean() functions in directional_statistics.h/cpp.
- - Added unscented_weights() and unscented_transform() functions in sigma_point.h/cpp.
+ - Added sigma_point(), unscented_weights() and unscented_transform() functions in sigma_point.h/cpp.
+ - Added UTWeight struct to store unscented transform weights in sigma_point.h/cpp.
+ - Added alias FunctionEvaluation in sigma_point.h/cpp.
 
 ##### `Test`
  - Added test_DirectionalStatisticsUtils for directional_statistics.h/cpp.

--- a/src/BayesFilters/include/BayesFilters/sigma_point.h
+++ b/src/BayesFilters/include/BayesFilters/sigma_point.h
@@ -16,7 +16,7 @@ namespace sigma_point
     void unscented_weights(const unsigned int n, const double alpha, const double beta, const double kappa,
                            Eigen::Ref<Eigen::VectorXd> weight_mean, Eigen::Ref<Eigen::VectorXd> weight_covariance, double& c);
 
-    Eigen::MatrixXd unscented_transform(const Gaussian& state, const double c);
+    Eigen::MatrixXd sigma_point(const Gaussian& state, const double c);
 
 }
 }

--- a/src/BayesFilters/include/BayesFilters/sigma_point.h
+++ b/src/BayesFilters/include/BayesFilters/sigma_point.h
@@ -1,9 +1,15 @@
 #ifndef SIGMAPOINT_H
 #define SIGMAPOINT_H
 
-#include <BayesFilters/Gaussian.h>
+#include <BayesFilters/AdditiveStateModel.h>
+#include <BayesFilters/Data.h>
+#include <BayesFilters/ExogenousModel.h>
+#include <BayesFilters/GaussianMixture.h>
+#include <BayesFilters/LinearMeasurementModel.h>
+#include <BayesFilters/MeasurementModel.h>
+#include <BayesFilters/StateModel.h>
 
-#include <cmath>
+#include <functional>
 
 #include <Eigen/Dense>
 
@@ -12,12 +18,39 @@ namespace bfl
 {
 namespace sigma_point
 {
+    using FunctionEvaluation = std::function<std::pair<bool, bfl::Data>(const Eigen::Ref<const Eigen::MatrixXf>&)>;
+    
+    struct UTWeight
+    {
+        Eigen::VectorXd mean;
+        Eigen::VectorXd cov;
+        /**
+         * c = sqrt(n + lambda) with lambda a ut parameter.
+         */
+        double c; 
 
-    void unscented_weights(const unsigned int n, const double alpha, const double beta, const double kappa,
-                           Eigen::Ref<Eigen::VectorXd> weight_mean, Eigen::Ref<Eigen::VectorXd> weight_covariance, double& c);
+        UTWeight(size_t n, const double alpha, const double beta, const double kappa);
+    };
 
-    Eigen::MatrixXd sigma_point(const Gaussian& state, const double c);
+    void unscented_weights(const size_t n, const double alpha, const double beta, const double kappa, Eigen::Ref<Eigen::VectorXd> weight_mean, Eigen::Ref<Eigen::VectorXd> weight_covariance, double& c);
 
+    Eigen::MatrixXd sigma_point(const GaussianMixture& state, const double c);
+
+    std::tuple<bool, GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& input, const UTWeight& weight, FunctionEvaluation function);
+
+    std::pair<GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, StateModel& state_model);
+
+    std::pair<GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, StateModel& state_model, ExogenousModel& exog_model);
+
+    std::pair<GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, AdditiveStateModel& state_model);
+
+    std::pair<GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, AdditiveStateModel& state_model, ExogenousModel& exog_model);
+
+    std::pair<GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, ExogenousModel& exog_model);
+
+    std::tuple<bool, GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, MeasurementModel& meas_model);
+
+    std::tuple<bool, GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, LinearMeasurementModel& meas_model);
 }
 }
 

--- a/src/BayesFilters/include/BayesFilters/sigma_point.h
+++ b/src/BayesFilters/include/BayesFilters/sigma_point.h
@@ -23,7 +23,7 @@ namespace sigma_point
     struct UTWeight
     {
         Eigen::VectorXd mean;
-        Eigen::VectorXd cov;
+        Eigen::VectorXd covariance;
         /**
          * c = sqrt(n + lambda) with lambda a ut parameter.
          */
@@ -40,13 +40,13 @@ namespace sigma_point
 
     std::pair<GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, StateModel& state_model);
 
-    std::pair<GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, StateModel& state_model, ExogenousModel& exog_model);
+    std::pair<GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, StateModel& state_model, ExogenousModel& exogenous_model);
 
     std::pair<GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, AdditiveStateModel& state_model);
 
-    std::pair<GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, AdditiveStateModel& state_model, ExogenousModel& exog_model);
+    std::pair<GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, AdditiveStateModel& state_model, ExogenousModel& exogenous_model);
 
-    std::pair<GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, ExogenousModel& exog_model);
+    std::pair<GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, ExogenousModel& exogenous_model);
 
     std::tuple<bool, GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, MeasurementModel& meas_model);
 

--- a/src/BayesFilters/include/BayesFilters/sigma_point.h
+++ b/src/BayesFilters/include/BayesFilters/sigma_point.h
@@ -29,10 +29,10 @@ namespace sigma_point
          */
         double c; 
 
-        UTWeight(size_t n, const double alpha, const double beta, const double kappa);
+        UTWeight(std::size_t n, const double alpha, const double beta, const double kappa);
     };
 
-    void unscented_weights(const size_t n, const double alpha, const double beta, const double kappa, Eigen::Ref<Eigen::VectorXd> weight_mean, Eigen::Ref<Eigen::VectorXd> weight_covariance, double& c);
+    void unscented_weights(const std::size_t n, const double alpha, const double beta, const double kappa, Eigen::Ref<Eigen::VectorXd> weight_mean, Eigen::Ref<Eigen::VectorXd> weight_covariance, double& c);
 
     Eigen::MatrixXd sigma_point(const GaussianMixture& state, const double c);
 

--- a/src/BayesFilters/src/sigma_point.cpp
+++ b/src/BayesFilters/src/sigma_point.cpp
@@ -11,7 +11,7 @@ using namespace Eigen;
 
 bfl::sigma_point::UTWeight::UTWeight
 (
-    size_t n,
+    std::size_t n,
     const double alpha,
     const double beta,
     const double kappa
@@ -24,7 +24,7 @@ bfl::sigma_point::UTWeight::UTWeight
 
 void bfl::sigma_point::unscented_weights
 (
-    const size_t n,
+    const std::size_t n,
     const double alpha,
     const double beta,
     const double kappa,

--- a/src/BayesFilters/src/sigma_point.cpp
+++ b/src/BayesFilters/src/sigma_point.cpp
@@ -16,7 +16,8 @@ bfl::sigma_point::UTWeight::UTWeight
     const double beta,
     const double kappa
 ) :
-    mean((2 * n) + 1), covariance((2 * n) + 1)
+    mean((2 * n) + 1),
+    covariance((2 * n) + 1)
 {
     unscented_weights(n, alpha, beta, kappa, mean, covariance, c);
 }

--- a/src/BayesFilters/src/sigma_point.cpp
+++ b/src/BayesFilters/src/sigma_point.cpp
@@ -32,7 +32,7 @@ void bfl::sigma_point::unscented_weights(const unsigned int n, const double alph
 }
 
 
-MatrixXd bfl::sigma_point::unscented_transform(const Gaussian& state, const double c)
+MatrixXd bfl::sigma_point::sigma_point(const Gaussian& state, const double c)
 {
     JacobiSVD<MatrixXd> svd = state.covariance().jacobiSvd(ComputeThinU);
 

--- a/test/test_SigmaPointUtils/main.cpp
+++ b/test/test_SigmaPointUtils/main.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <thread>
 
+#include <BayesFilters/Gaussian.h>
 #include <BayesFilters/sigma_point.h>
 
 using namespace bfl;
@@ -18,25 +19,20 @@ int main()
     double       beta  = 2.0;
     double       kappa = 0;
 
-    VectorXd wight_mean((2 * n) + 1);
-    VectorXd wight_covariance((2 * n) + 1);
-    double   c;
+    UTWeight weight(n, alpha, beta, kappa);
 
-    unscented_weights(n, alpha, beta, kappa,
-                      wight_mean, wight_covariance, c);
+    std::cout << "Weight mean:\n" << weight.mean << std::endl;
+    std::cout << "Weight sum: " << weight.mean.sum() << std::endl << std::endl;
 
-    std::cout << "Weight mean:\n" << wight_mean << std::endl;
-    std::cout << "Weight sum: " << wight_mean.sum() << std::endl << std::endl;
+    std::cout << "Covariance mean:\n" << weight.cov << std::endl;
+    std::cout << "Covariance sum: " << weight.cov.sum() << std::endl << std::endl;
 
-    std::cout << "Covariance mean:\n" << wight_covariance << std::endl;
-    std::cout << "Covariance sum: " << wight_covariance.sum() << std::endl << std::endl;
+    std::cout << "c: " << weight.c << std::endl << std::endl;
 
-    std::cout << "c: " << c << std::endl << std::endl;
+    VectorXd weight_mean_test((2 * n) + 1);
+    weight_mean_test << 0, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125;
 
-    VectorXd wight_mean_test((2 * n) + 1);
-    wight_mean_test << 0, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125;
-
-    if ((wight_mean - wight_mean_test).cwiseAbs().sum() > 0.0001)
+    if ((weight.mean - weight_mean_test).cwiseAbs().sum() > 0.0001)
     {
         std::cerr << "Wrong unscented weights of the mean." << std::endl;
         return EXIT_FAILURE;
@@ -44,10 +40,10 @@ int main()
     else
         std::cout << "Correct unscented weights of the mean." << std::endl;
 
-    VectorXd wight_covariance_test((2 * n) + 1);
-    wight_covariance_test << 2, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125;
+    VectorXd weight_covariance_test((2 * n) + 1);
+    weight_covariance_test << 2, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125;
 
-    if ((wight_covariance_test - wight_covariance_test).cwiseAbs().sum() > 0.0001)
+    if ((weight.cov - weight_covariance_test).cwiseAbs().sum() > 0.0001)
     {
         std::cerr << "Wrong unscented weights of the covariance." << std::endl;
         return EXIT_FAILURE;
@@ -64,9 +60,9 @@ int main()
                              0,   0,   0,   0,     0.157, 0,
                              0,   0,   0,   0,     0,     0.157;
 
-    MatrixXd sigma_points = unscented_transform(gaussian, c);
+    MatrixXd sigma_points = sigma_point::sigma_point(gaussian, weight.c);
 
-    std::cout << "Gaussian mean:\n" << gaussian.mean() << "\nGaussian covariance:\n" << gaussian.covariance() << "\nc: " << c << std::endl;
+    std::cout << "Gaussian mean:\n" << gaussian.mean() << "\nGaussian covariance:\n" << gaussian.covariance() << "\nc: " << weight.c << std::endl;
 
     std::cout << "Sigma points:\n" << sigma_points << std::endl;
 

--- a/test/test_SigmaPointUtils/main.cpp
+++ b/test/test_SigmaPointUtils/main.cpp
@@ -24,8 +24,8 @@ int main()
     std::cout << "Weight mean:\n" << weight.mean << std::endl;
     std::cout << "Weight sum: " << weight.mean.sum() << std::endl << std::endl;
 
-    std::cout << "Covariance mean:\n" << weight.cov << std::endl;
-    std::cout << "Covariance sum: " << weight.cov.sum() << std::endl << std::endl;
+    std::cout << "Covariance mean:\n" << weight.covariance << std::endl;
+    std::cout << "Covariance sum: " << weight.covariance.sum() << std::endl << std::endl;
 
     std::cout << "c: " << weight.c << std::endl << std::endl;
 
@@ -43,7 +43,7 @@ int main()
     VectorXd weight_covariance_test((2 * n) + 1);
     weight_covariance_test << 2, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125;
 
-    if ((weight.cov - weight_covariance_test).cwiseAbs().sum() > 0.0001)
+    if ((weight.covariance - weight_covariance_test).cwiseAbs().sum() > 0.0001)
     {
         std::cerr << "Wrong unscented weights of the covariance." << std::endl;
         return EXIT_FAILURE;


### PR DESCRIPTION
Within this PR:
- Renamed method `bfl::sigma_point::unscented_transform` to `bfl::sigma_point::sigma_point` (since the former method was evaluating the sigma points)
- Added struct `bfl::sigma_point::UTWeight` to initialize and store weights required to evaluate mean and covariance using the unscented transform
- Added alias `bfl::sigma_point::FunctionEvaluation` that represents a generic function `f(x)` to be used within method `bfl::sigma_point::unscented_transform`. The alias is of the form
  ```
  std::tuple<bool, bfl::Data>(const Eigen::Ref<const Eigen::MatrixXf>&)
  ```
  where `bfl::Data` is used, instead of a more straightforward `MatrixXf`, to cover possible future 
implementations where the specific type of data, wrapped by `bfl::Data`, is taken into account (e.g. in 
the evaluation of mean and covariance using unscented transform).
- Implemented a family of functions `bfl::sigma_point::unscented transform`:
  - a core method that takes as input a `GaussianMixture`, a `FunctionEvaluation` and the weights `UTWeight` and returns a boolean, the output `GaussianMixture` and a matrix of matrices containing the input-output cross-covariance matrix for each component of the mixture
  - several methods that work as an adapter between state and measurement models (e.g. `StateModel`, `AdditiveStateModel`, `MeasurementModel`, `LinearMeasurementModel` and `ExogenousModel`) and the core method, using lambda functions of type `bfl::sigma_point::FunctionEvaluation`

---

Comment on `bfl::sigma_point::unscented_transform` in commit ab8b3b9adf5e192d392ddef684d96b34cf177bd7.

My concern is the following: if a function type of the form
```
std::tuple<bool, MatrixXf>(const Eigen::Ref<const Eigen::MatrixXf>&)
```
is used, then, inside the lambda functions, the output of `MeasurementModel::predictedMeasure` must be converted to `MatrixXf` even if this is not the right type (especially if later one has to evaluate means and covariance).

By returning a `bfl::Data`, instead, a possible future implementation of the core method `bfl::sigma_point::unscented_transform` could delegate the evaluation of mean and covariance to a method that takes `bfl::Data` as input and does the right thing.