### PR TITLE
Solve discrepancy between float and double data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
  - Fourth number of the project version has been removed to be compliant with SemVer system.
  - Third number of SemVer increases since API compatibility is broken.
 
+#### `Data types`
+ - Using only double data type within the whole library.
+
 ##### `Filtering Algorithms`
  - Added logging capabilities to FilteringAlgorithm.
  - Constructor SIS::SIS takes the state size as argument (required to initialize ParticleSet).

--- a/src/BayesFilters/include/BayesFilters/AdditiveStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/AdditiveStateModel.h
@@ -15,11 +15,11 @@ class bfl::AdditiveStateModel : public bfl::StateModel
 public:
     virtual ~AdditiveStateModel() noexcept { };
 
-    virtual void motion(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> mot_states) override;
+    virtual void motion(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> mot_states) override;
 
-    virtual Eigen::MatrixXf getNoiseCovarianceMatrix() = 0;
+    virtual Eigen::MatrixXd getNoiseCovarianceMatrix() = 0;
 
-    virtual Eigen::MatrixXf getNoiseSample(const std::size_t num) = 0;
+    virtual Eigen::MatrixXd getNoiseSample(const std::size_t num) = 0;
 };
 
 #endif /* ADDITIVESTATEMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/EstimatesExtraction.h
+++ b/src/BayesFilters/include/BayesFilters/EstimatesExtraction.h
@@ -42,7 +42,7 @@ public:
 
     bool setMobileAverageWindowSize(const int window);
 
-    Eigen::VectorXf extract(const Eigen::Ref<const Eigen::MatrixXf>& particles, const Eigen::Ref<const Eigen::VectorXf>& weights);
+    Eigen::VectorXd extract(const Eigen::Ref<const Eigen::MatrixXd>& particles, const Eigen::Ref<const Eigen::VectorXd>& weights);
 
     bool clear();
 
@@ -54,9 +54,9 @@ protected:
 
     HistoryBuffer hist_buffer_;
 
-    Eigen::VectorXf sm_weights_;
-    Eigen::VectorXf wm_weights_;
-    Eigen::VectorXf em_weights_;
+    Eigen::VectorXd sm_weights_;
+    Eigen::VectorXd wm_weights_;
+    Eigen::VectorXd em_weights_;
 
 
     enum class Statistics
@@ -65,17 +65,17 @@ protected:
         mode
     };
 
-    Eigen::VectorXf mean(const Eigen::Ref<const Eigen::MatrixXf>& particles, const Eigen::Ref<const Eigen::VectorXf>& weights) const;
+    Eigen::VectorXd mean(const Eigen::Ref<const Eigen::MatrixXd>& particles, const Eigen::Ref<const Eigen::VectorXd>& weights) const;
 
-    Eigen::VectorXf mode(const Eigen::Ref<const Eigen::MatrixXf>& particles, const Eigen::Ref<const Eigen::VectorXf>& weights) const;
+    Eigen::VectorXd mode(const Eigen::Ref<const Eigen::MatrixXd>& particles, const Eigen::Ref<const Eigen::VectorXd>& weights) const;
 
-    Eigen::VectorXf simpleAverage(const Eigen::Ref<const Eigen::MatrixXf>& particles, const Eigen::Ref<const Eigen::VectorXf>& weights,
+    Eigen::VectorXd simpleAverage(const Eigen::Ref<const Eigen::MatrixXd>& particles, const Eigen::Ref<const Eigen::VectorXd>& weights,
                                   const Statistics& base_est_ext);
 
-    Eigen::VectorXf weightedAverage(const Eigen::Ref<const Eigen::MatrixXf>& particles, const Eigen::Ref<const Eigen::VectorXf>& weights,
+    Eigen::VectorXd weightedAverage(const Eigen::Ref<const Eigen::MatrixXd>& particles, const Eigen::Ref<const Eigen::VectorXd>& weights,
                                     const Statistics& base_est_ext);
 
-    Eigen::VectorXf exponentialAverage(const Eigen::Ref<const Eigen::MatrixXf>& particles, const Eigen::Ref<const Eigen::VectorXf>& weights,
+    Eigen::VectorXd exponentialAverage(const Eigen::Ref<const Eigen::MatrixXd>& particles, const Eigen::Ref<const Eigen::VectorXd>& weights,
                                        const Statistics& base_est_ext);
 };
 

--- a/src/BayesFilters/include/BayesFilters/ExogenousModel.h
+++ b/src/BayesFilters/include/BayesFilters/ExogenousModel.h
@@ -13,9 +13,9 @@ class bfl::ExogenousModel
 public:
     virtual ~ExogenousModel() noexcept { };
 
-    virtual void propagate(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> prop_states) = 0;
+    virtual void propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> prop_states) = 0;
 
-    virtual Eigen::MatrixXf getExogenousMatrix() = 0;
+    virtual Eigen::MatrixXd getExogenousMatrix() = 0;
 
     virtual bool setProperty(const std::string& property) = 0;
 };

--- a/src/BayesFilters/include/BayesFilters/GaussianLikelihood.h
+++ b/src/BayesFilters/include/BayesFilters/GaussianLikelihood.h
@@ -18,7 +18,7 @@ public:
     virtual ~GaussianLikelihood() noexcept { };
 
 protected:
-    std::pair<bool, Eigen::VectorXf> likelihood(const MeasurementModel& measurement_model, const Eigen::Ref<const Eigen::MatrixXf>& pred_states) override;
+    std::pair<bool, Eigen::VectorXd> likelihood(const MeasurementModel& measurement_model, const Eigen::Ref<const Eigen::MatrixXd>& pred_states) override;
 
     double scale_factor_;
 };

--- a/src/BayesFilters/include/BayesFilters/HistoryBuffer.h
+++ b/src/BayesFilters/include/BayesFilters/HistoryBuffer.h
@@ -21,9 +21,9 @@ public:
 
     ~HistoryBuffer() noexcept { };
 
-    void            addElement(const Eigen::Ref<const Eigen::VectorXf>& element);
+    void            addElement(const Eigen::Ref<const Eigen::VectorXd>& element);
 
-    Eigen::MatrixXf getHistoryBuffer() const;
+    Eigen::MatrixXd getHistoryBuffer() const;
 
     bool            setHistorySize(const unsigned int window);
 
@@ -40,7 +40,7 @@ private:
 
     const unsigned int          max_window_ = 30;
 
-    std::deque<Eigen::VectorXf> history_buffer_;
+    std::deque<Eigen::VectorXd> history_buffer_;
 };
 
 #endif /* HISTORYBUFFER_H */

--- a/src/BayesFilters/include/BayesFilters/LTIMeasurementModel.h
+++ b/src/BayesFilters/include/BayesFilters/LTIMeasurementModel.h
@@ -13,20 +13,20 @@ namespace bfl {
 class bfl::LTIMeasurementModel : public bfl::LinearMeasurementModel
 {
 public:
-    LTIMeasurementModel(const Eigen::Ref<const Eigen::MatrixXf>& measurement_matrix, const Eigen::Ref<const Eigen::MatrixXf>& noise_covariance_matrix);
+    LTIMeasurementModel(const Eigen::Ref<const Eigen::MatrixXd>& measurement_matrix, const Eigen::Ref<const Eigen::MatrixXd>& noise_covariance_matrix);
 
     virtual ~LTIMeasurementModel() noexcept { };
 
-    std::pair<bool, Eigen::MatrixXf> getNoiseCovarianceMatrix() const override;
+    std::pair<bool, Eigen::MatrixXd> getNoiseCovarianceMatrix() const override;
 
-    Eigen::MatrixXf getMeasurementMatrix() const override;
+    Eigen::MatrixXd getMeasurementMatrix() const override;
 
 protected:
     /* Measurement matrix. */
-    Eigen::MatrixXf H_;
+    Eigen::MatrixXd H_;
 
     /* Matrix covariance of the zero mean additive white measurement noise. */
-    Eigen::MatrixXf R_;
+    Eigen::MatrixXd R_;
 };
 
 #endif /* LTIMEMEASUREMENTMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/LTIStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/LTIStateModel.h
@@ -13,30 +13,30 @@ namespace bfl {
 class bfl::LTIStateModel : public bfl::LinearStateModel
 {
 public:
-    LTIStateModel(const Eigen::Ref<const Eigen::MatrixXf>& transition_matrix, const Eigen::Ref<const Eigen::MatrixXf>& noise_covariance_matrix);
+    LTIStateModel(const Eigen::Ref<const Eigen::MatrixXd>& transition_matrix, const Eigen::Ref<const Eigen::MatrixXd>& noise_covariance_matrix);
 
     virtual ~LTIStateModel() noexcept { };
 
-    void propagate(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> prop_states) override;
+    void propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> prop_states) override;
 
-    Eigen::MatrixXf getNoiseCovarianceMatrix() override;
+    Eigen::MatrixXd getNoiseCovarianceMatrix() override;
 
-    Eigen::MatrixXf getStateTransitionMatrix() override;
+    Eigen::MatrixXd getStateTransitionMatrix() override;
 
     bool setProperty(const std::string& property) override;
 
-    Eigen::MatrixXf getJacobian() override;
+    Eigen::MatrixXd getJacobian() override;
 
 protected:
     /*
      * State transition matrix.
      */
-    Eigen::MatrixXf F_;
+    Eigen::MatrixXd F_;
 
     /*
      * Noise covariance matrix of zero mean additive white noise.
      */
-    Eigen::MatrixXf Q_;
+    Eigen::MatrixXd Q_;
 };
 
 #endif /* LTISTATEMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/LikelihoodModel.h
+++ b/src/BayesFilters/include/BayesFilters/LikelihoodModel.h
@@ -15,7 +15,7 @@ class bfl::LikelihoodModel
 public:
     virtual ~LikelihoodModel() noexcept { };
 
-    virtual std::pair<bool, Eigen::VectorXf> likelihood(const MeasurementModel& measurement_model, const Eigen::Ref<const Eigen::MatrixXf>& pred_states) = 0;
+    virtual std::pair<bool, Eigen::VectorXd> likelihood(const MeasurementModel& measurement_model, const Eigen::Ref<const Eigen::MatrixXd>& pred_states) = 0;
 };
 
 #endif /* LIKELIHOODMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/LinearMeasurementModel.h
+++ b/src/BayesFilters/include/BayesFilters/LinearMeasurementModel.h
@@ -15,9 +15,9 @@ class bfl::LinearMeasurementModel : public MeasurementModel
 public:
     virtual ~LinearMeasurementModel() noexcept { };
 
-    virtual Eigen::MatrixXf getMeasurementMatrix() const = 0;
+    virtual Eigen::MatrixXd getMeasurementMatrix() const = 0;
 
-    virtual std::pair<bool, bfl::Data> predictedMeasure(const Eigen::Ref<const Eigen::MatrixXf>& cur_states) const override;
+    virtual std::pair<bool, bfl::Data> predictedMeasure(const Eigen::Ref<const Eigen::MatrixXd>& cur_states) const override;
 
     virtual std::pair<bool, bfl::Data> innovation(const bfl::Data& predicted_measurements, const bfl::Data& measurements) const override;
 };

--- a/src/BayesFilters/include/BayesFilters/LinearModel.h
+++ b/src/BayesFilters/include/BayesFilters/LinearModel.h
@@ -16,9 +16,9 @@ namespace bfl {
 class bfl::LinearModel : public LinearMeasurementModel
 {
 public:
-    LinearModel(const float sigma_x, const float sigma_y, const unsigned int seed) noexcept;
+    LinearModel(const double sigma_x, const double sigma_y, const unsigned int seed) noexcept;
 
-    LinearModel(const float sigma_x, const float sigma_y) noexcept;
+    LinearModel(const double sigma_x, const double sigma_y) noexcept;
 
     LinearModel() noexcept;
 
@@ -32,57 +32,57 @@ public:
 
     LinearModel& operator=(LinearModel&& lin_sense) noexcept;
 
-    std::pair<bool, Eigen::MatrixXf> getNoiseCovarianceMatrix() const override;
+    std::pair<bool, Eigen::MatrixXd> getNoiseCovarianceMatrix() const override;
 
-    Eigen::MatrixXf getMeasurementMatrix() const override;
+    Eigen::MatrixXd getMeasurementMatrix() const override;
 
 private:
     std::mt19937_64 generator_;
 
-    std::normal_distribution<float> distribution_;
+    std::normal_distribution<double> distribution_;
 
     bool log_enabled_ = false;
 
     mutable std::ofstream log_file_measurements_;
 
 protected:
-    std::pair<bool, Eigen::MatrixXf> getNoiseSample(const int num) const;
+    std::pair<bool, Eigen::MatrixXd> getNoiseSample(const int num) const;
     
     /**
      * The Sampling interval in [time].
      */
-    float T_;
+    double T_;
 
     /**
      * x-axis measurement noise std deviation in [length].
      */
-    float sigma_x_;
+    double sigma_x_;
 
     /**
      * y-axis measurement noise std deviation in [length].
      */
-    float sigma_y_;
+    double sigma_y_;
 
     /**
      * Measurement matrix.
      */
-    Eigen::MatrixXf H_;
+    Eigen::MatrixXd H_;
 
     /**
      * Convariance matrix of the additive white noise of the measurements.
      */
-    Eigen::Matrix2f R_;
+    Eigen::Matrix2d R_;
 
     /**
      * Square root matrix of R_.
      */
-    Eigen::Matrix2f sqrt_R_;
+    Eigen::Matrix2d sqrt_R_;
 
     /**
      * Random number generator function from a Normal distribution.
-     * A call to `gauss_rnd_sample_()` returns a floating point random number.
+     * A call to `gauss_rnd_sample_()` returns a doubleing point random number.
      */
-    std::function<float()> gauss_rnd_sample_;
+    std::function<double()> gauss_rnd_sample_;
 
     std::vector<std::string> log_filenames(const std::string& prefix_path, const std::string& prefix_name) override
     {

--- a/src/BayesFilters/include/BayesFilters/LinearStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/LinearStateModel.h
@@ -15,9 +15,9 @@ class bfl::LinearStateModel : public bfl::AdditiveStateModel
 public:
     virtual ~LinearStateModel() noexcept { };
 
-    virtual void propagate(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> mot_states) override;
+    virtual void propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> mot_states) override;
 
-    virtual Eigen::MatrixXf getStateTransitionMatrix() = 0;
+    virtual Eigen::MatrixXd getStateTransitionMatrix() = 0;
 };
 
 #endif /* LINEARSTATEMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/MeasurementModel.h
+++ b/src/BayesFilters/include/BayesFilters/MeasurementModel.h
@@ -22,11 +22,11 @@ public:
 
     virtual std::pair<bool, bfl::Data> measure() const = 0;
 
-    virtual std::pair<bool, bfl::Data> predictedMeasure(const Eigen::Ref<const Eigen::MatrixXf>& cur_states) const = 0;
+    virtual std::pair<bool, bfl::Data> predictedMeasure(const Eigen::Ref<const Eigen::MatrixXd>& cur_states) const = 0;
 
     virtual std::pair<bool, bfl::Data> innovation(const bfl::Data& predicted_measurements, const bfl::Data& measurements) const = 0;
 
-    virtual std::pair<bool, Eigen::MatrixXf> getNoiseCovarianceMatrix() const;
+    virtual std::pair<bool, Eigen::MatrixXd> getNoiseCovarianceMatrix() const;
 
     virtual bool setProperty(const std::string& property);
 

--- a/src/BayesFilters/include/BayesFilters/MeasurementModelDecorator.h
+++ b/src/BayesFilters/include/BayesFilters/MeasurementModelDecorator.h
@@ -15,11 +15,11 @@ class bfl::MeasurementModelDecorator : public MeasurementModel
 public:
     std::pair<bool, bfl::Data> measure() const override;
 
-    std::pair<bool, bfl::Data> predictedMeasure(const Eigen::Ref<const Eigen::MatrixXf>& cur_states) const override;
+    std::pair<bool, bfl::Data> predictedMeasure(const Eigen::Ref<const Eigen::MatrixXd>& cur_states) const override;
 
     std::pair<bool, bfl::Data> innovation(const bfl::Data& predicted_measurements, const bfl::Data& measurements) const override;
 
-    std::pair<bool, Eigen::MatrixXf> getNoiseCovarianceMatrix() const override;
+    std::pair<bool, Eigen::MatrixXd> getNoiseCovarianceMatrix() const override;
 
     bool setProperty(const std::string& property) override;
 

--- a/src/BayesFilters/include/BayesFilters/PFCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/PFCorrection.h
@@ -28,7 +28,7 @@ public:
 
     virtual void setMeasurementModel(std::unique_ptr<MeasurementModel> measurement_model) = 0;
 
-    virtual std::pair<bool, Eigen::VectorXf> getLikelihood() = 0;
+    virtual std::pair<bool, Eigen::VectorXd> getLikelihood() = 0;
 
 protected:
     /* FIXME

--- a/src/BayesFilters/include/BayesFilters/PFCorrectionDecorator.h
+++ b/src/BayesFilters/include/BayesFilters/PFCorrectionDecorator.h
@@ -18,7 +18,7 @@ public:
 
     void setMeasurementModel(std::unique_ptr<MeasurementModel> measurement_model) override;
 
-    std::pair<bool, Eigen::VectorXf> getLikelihood() override;
+    std::pair<bool, Eigen::VectorXd> getLikelihood() override;
 
 protected:
     PFCorrectionDecorator(std::unique_ptr<PFCorrection> correction) noexcept;

--- a/src/BayesFilters/include/BayesFilters/Resampling.h
+++ b/src/BayesFilters/include/BayesFilters/Resampling.h
@@ -34,7 +34,7 @@ public:
     virtual void resample(const bfl::ParticleSet& cor_particles, bfl::ParticleSet& res_particles,
                           Eigen::Ref<Eigen::VectorXi> res_parents);
 
-    virtual float neff(const Eigen::Ref<const Eigen::VectorXf>& cor_weights);
+    virtual double neff(const Eigen::Ref<const Eigen::VectorXd>& cor_weights);
 
 private:
     std::mt19937_64 generator_;

--- a/src/BayesFilters/include/BayesFilters/ResamplingWithPrior.h
+++ b/src/BayesFilters/include/BayesFilters/ResamplingWithPrior.h
@@ -39,7 +39,7 @@ protected:
     double prior_ratio_ = 0.5;
 
 private:
-    std::vector<unsigned int> sort_indices(const Eigen::Ref<const Eigen::VectorXf>& vector);
+    std::vector<unsigned int> sort_indices(const Eigen::Ref<const Eigen::VectorXd>& vector);
 };
 
 #endif /* RESAMPLINGWITHPRIOR_H */

--- a/src/BayesFilters/include/BayesFilters/SPCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/SPCorrection.h
@@ -30,12 +30,12 @@ public:
 
     std::unique_ptr<MeasurementModel> measurement_model_;
 
-    virtual std::pair<bool, Eigen::VectorXf> getLikelihood();
+    virtual std::pair<bool, Eigen::VectorXd> getLikelihood();
 
 protected:
     virtual Gaussian correctStep(const Gaussian& prev_state) = 0;
 
-    virtual std::pair<bool, Eigen::VectorXf> likelihood(const Eigen::Ref<const Eigen::MatrixXf>& innovations) = 0;
+    virtual std::pair<bool, Eigen::VectorXd> likelihood(const Eigen::Ref<const Eigen::MatrixXd>& innovations) = 0;
 
     SPCorrection() noexcept;
 

--- a/src/BayesFilters/include/BayesFilters/SimulatedLinearSensor.h
+++ b/src/BayesFilters/include/BayesFilters/SimulatedLinearSensor.h
@@ -14,9 +14,9 @@ namespace bfl {
 class bfl::SimulatedLinearSensor : public LinearModel
 {
 public:
-    SimulatedLinearSensor(std::unique_ptr<bfl::SimulatedStateModel> simulated_state_model, const float sigma_x, const float sigma_y, const unsigned int seed);
+    SimulatedLinearSensor(std::unique_ptr<bfl::SimulatedStateModel> simulated_state_model, const double sigma_x, const double sigma_y, const unsigned int seed);
 
-    SimulatedLinearSensor(std::unique_ptr<bfl::SimulatedStateModel> simulated_state_model, const float sigma_x, const float sigma_y);
+    SimulatedLinearSensor(std::unique_ptr<bfl::SimulatedStateModel> simulated_state_model, const double sigma_x, const double sigma_y);
 
     SimulatedLinearSensor(std::unique_ptr<bfl::SimulatedStateModel> simulated_state_model);
 
@@ -29,7 +29,7 @@ public:
 protected:
     std::unique_ptr<bfl::SimulatedStateModel> simulated_state_model_;
 
-    Eigen::MatrixXf measurement_;
+    Eigen::MatrixXd measurement_;
 };
 
 #endif /* SIMULATEDLINEARSENSOR_H */

--- a/src/BayesFilters/include/BayesFilters/SimulatedStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/SimulatedStateModel.h
@@ -16,7 +16,7 @@ namespace bfl {
 class bfl::SimulatedStateModel : public Agent, public Logger
 {
 public:
-    SimulatedStateModel(std::unique_ptr<StateModel> state_model, const Eigen::Ref<const Eigen::VectorXf>& initial_state, const unsigned int simulation_time);
+    SimulatedStateModel(std::unique_ptr<StateModel> state_model, const Eigen::Ref<const Eigen::VectorXd>& initial_state, const unsigned int simulation_time);
 
     virtual ~SimulatedStateModel() noexcept;
 
@@ -29,7 +29,7 @@ public:
 private:
     unsigned int simulation_time_;
 
-    Eigen::MatrixXf target_;
+    Eigen::MatrixXd target_;
 
 protected:
     std::unique_ptr<StateModel> state_model_;

--- a/src/BayesFilters/include/BayesFilters/StateModel.h
+++ b/src/BayesFilters/include/BayesFilters/StateModel.h
@@ -13,13 +13,13 @@ class bfl::StateModel
 public:
     virtual ~StateModel() noexcept { };
 
-    virtual void propagate(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> prop_states) = 0;
+    virtual void propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> prop_states) = 0;
 
-    virtual void motion(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> mot_states) = 0;
+    virtual void motion(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> mot_states) = 0;
 
-    virtual Eigen::MatrixXf getJacobian();
+    virtual Eigen::MatrixXd getJacobian();
 
-    virtual Eigen::VectorXf getTransitionProbability(const Eigen::Ref<const Eigen::MatrixXf>& prev_states, Eigen::Ref<Eigen::MatrixXf> cur_states);
+    virtual Eigen::VectorXd getTransitionProbability(const Eigen::Ref<const Eigen::MatrixXd>& prev_states, Eigen::Ref<Eigen::MatrixXd> cur_states);
 
     virtual bool setProperty(const std::string& property) = 0;
 };

--- a/src/BayesFilters/include/BayesFilters/StateModelDecorator.h
+++ b/src/BayesFilters/include/BayesFilters/StateModelDecorator.h
@@ -13,9 +13,9 @@ namespace bfl {
 class bfl::StateModelDecorator : public StateModel
 {
 public:
-    void propagate(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> prop_states) override;
+    void propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> prop_states) override;
 
-    void motion(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> mot_states) override;
+    void motion(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> mot_states) override;
 
     bool setProperty(const std::string& property) override;
 

--- a/src/BayesFilters/include/BayesFilters/UpdateParticles.h
+++ b/src/BayesFilters/include/BayesFilters/UpdateParticles.h
@@ -23,7 +23,7 @@ public:
 
     void setMeasurementModel(std::unique_ptr<MeasurementModel> measurement_model) override;
 
-    std::pair<bool, Eigen::VectorXf> getLikelihood() override;
+    std::pair<bool, Eigen::VectorXd> getLikelihood() override;
 
 protected:
     std::unique_ptr<LikelihoodModel> likelihood_model_;
@@ -37,7 +37,7 @@ protected:
     void correctStep(const ParticleSet& pred_particles, ParticleSet& cor_particles) override;
 
     bool valid_likelihood_ = false;
-    Eigen::VectorXf likelihood_;
+    Eigen::VectorXd likelihood_;
 };
 
 #endif /* UPDATEPARTICLES_H */

--- a/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
+++ b/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
@@ -14,9 +14,9 @@ namespace bfl {
 class bfl::WhiteNoiseAcceleration : public LinearStateModel
 {
 public:
-    WhiteNoiseAcceleration(float T, float tilde_q, unsigned int seed) noexcept;
+    WhiteNoiseAcceleration(double T, double tilde_q, unsigned int seed) noexcept;
 
-    WhiteNoiseAcceleration(float T, float tilde_q) noexcept;
+    WhiteNoiseAcceleration(double T, double tilde_q) noexcept;
 
     WhiteNoiseAcceleration() noexcept;
 
@@ -30,50 +30,50 @@ public:
 
     WhiteNoiseAcceleration& operator=(WhiteNoiseAcceleration&& wna) noexcept;
 
-    Eigen::MatrixXf getNoiseSample(const std::size_t num) override;
+    Eigen::MatrixXd getNoiseSample(const std::size_t num) override;
 
-    Eigen::MatrixXf getNoiseCovarianceMatrix() override;
+    Eigen::MatrixXd getNoiseCovarianceMatrix() override;
 
-    Eigen::MatrixXf getStateTransitionMatrix() override;
+    Eigen::MatrixXd getStateTransitionMatrix() override;
 
     bool setProperty(const std::string& property) override { return false; };
 
 private:
     std::mt19937_64 generator_;
 
-    std::normal_distribution<float> distribution_;
+    std::normal_distribution<double> distribution_;
 
 protected:
     /**
      * Sampling interval in [time].
      */
-    float T_;
+    double T_;
 
     /**
      * State transition matrix.
      */
-    Eigen::Matrix4f F_;
+    Eigen::Matrix4d F_;
 
     /**
      * Convariance matrix of the additive white noise of the state model.
      */
-    Eigen::Matrix4f Q_;
+    Eigen::Matrix4d Q_;
 
     /**
      * Power spectral density [length]^2/[time]^3.
      */
-    float tilde_q_;
+    double tilde_q_;
 
     /**
      * Square root matrix of R_.
      */
-    Eigen::Matrix4f sqrt_Q_;
+    Eigen::Matrix4d sqrt_Q_;
 
     /**
      * Random number generator function from a Normal distribution.
-     * A call to `gauss_rnd_sample_()` returns a floating point random number.
+     * A call to `gauss_rnd_sample_()` returns a double-precision floating point random number.
      */
-    std::function<float()> gauss_rnd_sample_;
+    std::function<double()> gauss_rnd_sample_;
 };
 
 #endif /* WHITENOISEACCELERATION_H */

--- a/src/BayesFilters/include/BayesFilters/sigma_point.h
+++ b/src/BayesFilters/include/BayesFilters/sigma_point.h
@@ -18,7 +18,7 @@ namespace bfl
 {
 namespace sigma_point
 {
-    using FunctionEvaluation = std::function<std::pair<bool, bfl::Data>(const Eigen::Ref<const Eigen::MatrixXf>&)>;
+    using FunctionEvaluation = std::function<std::pair<bool, bfl::Data>(const Eigen::Ref<const Eigen::MatrixXd>&)>;
     
     struct UTWeight
     {

--- a/src/BayesFilters/src/AdditiveStateModel.cpp
+++ b/src/BayesFilters/src/AdditiveStateModel.cpp
@@ -5,7 +5,7 @@
 using namespace bfl;
 using namespace Eigen;
 
-void AdditiveStateModel::motion(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> mot_states)
+void AdditiveStateModel::motion(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> mot_states)
 {
     propagate(cur_states, mot_states);
     mot_states += getNoiseSample(mot_states.cols());

--- a/src/BayesFilters/src/DrawParticles.cpp
+++ b/src/BayesFilters/src/DrawParticles.cpp
@@ -18,11 +18,7 @@ DrawParticles::~DrawParticles() noexcept { }
 
 void DrawParticles::predictStep(const ParticleSet& prev_particles, ParticleSet& pred_particles)
 {
-    /* Temporary variable required until discrepancy between
-       MatrixXf and MatrixXd is solved. */
-    MatrixXf tmp(pred_particles.dim, pred_particles.components);
-    state_model_->motion(prev_particles.state().cast<float>(), tmp);
-    pred_particles.state() = std::move(tmp.cast<double>());
+    state_model_->motion(prev_particles.state(), pred_particles.state());
 
     pred_particles.weight() = prev_particles.weight();
 }

--- a/src/BayesFilters/src/EstimatesExtraction.cpp
+++ b/src/BayesFilters/src/EstimatesExtraction.cpp
@@ -50,9 +50,9 @@ bool EstimatesExtraction::setMobileAverageWindowSize(const int window)
 }
 
 
-VectorXf EstimatesExtraction::extract(const Ref<const MatrixXf>& particles, const Ref<const VectorXf>& weights)
+VectorXd EstimatesExtraction::extract(const Ref<const MatrixXd>& particles, const Ref<const VectorXd>& weights)
 {
-    VectorXf out_particle(7);
+    VectorXd out_particle(7);
     switch (extraction_method_)
     {
         case ExtractionMethod::mean :
@@ -117,11 +117,11 @@ std::vector<std::string> EstimatesExtraction::getInfo() const
 }
 
 
-VectorXf EstimatesExtraction::mean(const Ref<const MatrixXf>& particles, const Ref<const VectorXf>& weights) const
+VectorXd EstimatesExtraction::mean(const Ref<const MatrixXd>& particles, const Ref<const VectorXd>& weights) const
 {
-    VectorXf out_particle = VectorXf::Zero(7);
-    float    s_ang        = 0;
-    float    c_ang        = 0;
+    VectorXd out_particle = VectorXd::Zero(7);
+    double    s_ang        = 0;
+    double    c_ang        = 0;
 
     for (int i = 0; i < particles.cols(); ++i)
     {
@@ -132,7 +132,7 @@ VectorXf EstimatesExtraction::mean(const Ref<const MatrixXf>& particles, const R
         c_ang += weights(i) * std::cos(particles(6, i));
     }
 
-    float versor_norm = out_particle.middleRows<3>(3).norm();
+    double versor_norm = out_particle.middleRows<3>(3).norm();
     if (versor_norm >= 0.99)
         out_particle.middleRows<3>(3) /= versor_norm;
     else
@@ -144,20 +144,20 @@ VectorXf EstimatesExtraction::mean(const Ref<const MatrixXf>& particles, const R
 }
 
 
-VectorXf EstimatesExtraction::mode(const Ref<const MatrixXf>& particles, const Ref<const VectorXf>& weights) const
+VectorXd EstimatesExtraction::mode(const Ref<const MatrixXd>& particles, const Ref<const VectorXd>& weights) const
 {
-    MatrixXf::Index maxRow;
-    MatrixXf::Index maxCol;
+    MatrixXd::Index maxRow;
+    MatrixXd::Index maxCol;
     weights.maxCoeff(&maxRow, &maxCol);
 
     return particles.col(maxRow);
 }
 
 
-VectorXf EstimatesExtraction::simpleAverage(const Ref<const MatrixXf>& particles, const Ref<const VectorXf>& weights,
+VectorXd EstimatesExtraction::simpleAverage(const Ref<const MatrixXd>& particles, const Ref<const VectorXd>& weights,
                                             const Statistics& base_est_ext)
 {
-    VectorXf cur_estimates;
+    VectorXd cur_estimates;
     if (base_est_ext == Statistics::mean)
         cur_estimates = mean(particles, weights);
     else if (base_est_ext == Statistics::mode)
@@ -166,19 +166,19 @@ VectorXf EstimatesExtraction::simpleAverage(const Ref<const MatrixXf>& particles
 
     hist_buffer_.addElement(cur_estimates);
 
-    MatrixXf history = hist_buffer_.getHistoryBuffer();
+    MatrixXd history = hist_buffer_.getHistoryBuffer();
     if (sm_weights_.size() != history.cols())
-        sm_weights_ = VectorXf::Ones(history.cols()) / history.cols();
+        sm_weights_ = VectorXd::Ones(history.cols()) / history.cols();
 
 
     return mean(history, sm_weights_);
 }
 
 
-VectorXf EstimatesExtraction::weightedAverage(const Ref<const MatrixXf>& particles, const Ref<const VectorXf>& weights,
+VectorXd EstimatesExtraction::weightedAverage(const Ref<const MatrixXd>& particles, const Ref<const VectorXd>& weights,
                                               const Statistics& base_est_ext)
 {
-    VectorXf cur_estimates;
+    VectorXd cur_estimates;
     if (base_est_ext == Statistics::mean)
         cur_estimates = mean(particles, weights);
     else if (base_est_ext == Statistics::mode)
@@ -187,7 +187,7 @@ VectorXf EstimatesExtraction::weightedAverage(const Ref<const MatrixXf>& particl
 
     hist_buffer_.addElement(cur_estimates);
 
-    MatrixXf history = hist_buffer_.getHistoryBuffer();
+    MatrixXd history = hist_buffer_.getHistoryBuffer();
     if (wm_weights_.size() != history.cols())
     {
         wm_weights_.resize(history.cols());
@@ -202,10 +202,10 @@ VectorXf EstimatesExtraction::weightedAverage(const Ref<const MatrixXf>& particl
 }
 
 
-VectorXf EstimatesExtraction::exponentialAverage(const Ref<const MatrixXf>& particles, const Ref<const VectorXf>& weights,
+VectorXd EstimatesExtraction::exponentialAverage(const Ref<const MatrixXd>& particles, const Ref<const VectorXd>& weights,
                                                  const Statistics& base_est_ext)
 {
-    VectorXf cur_estimates;
+    VectorXd cur_estimates;
     if (base_est_ext == Statistics::mean)
         cur_estimates = mean(particles, weights);
     else if (base_est_ext == Statistics::mode)
@@ -214,7 +214,7 @@ VectorXf EstimatesExtraction::exponentialAverage(const Ref<const MatrixXf>& part
 
     hist_buffer_.addElement(cur_estimates);
 
-    MatrixXf history = hist_buffer_.getHistoryBuffer();
+    MatrixXd history = hist_buffer_.getHistoryBuffer();
     if (em_weights_.size() != history.cols())
     {
         em_weights_.resize(history.cols());

--- a/src/BayesFilters/src/EstimatesExtraction.cpp
+++ b/src/BayesFilters/src/EstimatesExtraction.cpp
@@ -120,8 +120,8 @@ std::vector<std::string> EstimatesExtraction::getInfo() const
 VectorXd EstimatesExtraction::mean(const Ref<const MatrixXd>& particles, const Ref<const VectorXd>& weights) const
 {
     VectorXd out_particle = VectorXd::Zero(7);
-    double    s_ang        = 0;
-    double    c_ang        = 0;
+    double   s_ang        = 0;
+    double   c_ang        = 0;
 
     for (int i = 0; i < particles.cols(); ++i)
     {

--- a/src/BayesFilters/src/GaussianLikelihood.cpp
+++ b/src/BayesFilters/src/GaussianLikelihood.cpp
@@ -12,56 +12,56 @@ GaussianLikelihood::GaussianLikelihood(const double scale_factor) noexcept :
     scale_factor_(scale_factor) { }
 
 
-std::pair<bool, VectorXf> GaussianLikelihood::likelihood
+std::pair<bool, VectorXd> GaussianLikelihood::likelihood
 (
     const MeasurementModel& measurement_model,
-    const Ref<const MatrixXf>& pred_states
+    const Ref<const MatrixXd>& pred_states
 )
 {
     bool valid_measurements;
     Data data_measurements;
     std::tie(valid_measurements, data_measurements) = measurement_model.measure();
 
-    MatrixXf measurements;
+    MatrixXd measurements;
     if (valid_measurements)
-        measurements = any::any_cast<MatrixXf&&>(std::move(data_measurements));
+        measurements = any::any_cast<MatrixXd&&>(std::move(data_measurements));
     else
-        return std::make_pair(false, VectorXf::Zero(1));
+        return std::make_pair(false, VectorXd::Zero(1));
 
 
     bool valid_predicted_measurements;
     Data data_predicted_measurements;
     std::tie(valid_predicted_measurements, data_predicted_measurements) = measurement_model.predictedMeasure(pred_states);
 
-    MatrixXf predicted_measurements;
+    MatrixXd predicted_measurements;
     if (valid_predicted_measurements)
-        predicted_measurements = any::any_cast<MatrixXf&&>(std::move(data_predicted_measurements));
+        predicted_measurements = any::any_cast<MatrixXd&&>(std::move(data_predicted_measurements));
     else
-        return std::make_pair(false, VectorXf::Zero(1));
+        return std::make_pair(false, VectorXd::Zero(1));
 
 
     bool valid_innovation;
     Data data_innovations;
     std::tie(valid_innovation, data_innovations) = measurement_model.innovation(predicted_measurements, measurements);
 
-    MatrixXf innovations;
+    MatrixXd innovations;
     if (valid_innovation)
-        innovations = any::any_cast<MatrixXf&&>(std::move(data_innovations));
+        innovations = any::any_cast<MatrixXd&&>(std::move(data_innovations));
     else
-        return std::make_pair(false, VectorXf::Zero(1));
+        return std::make_pair(false, VectorXd::Zero(1));
 
 
-    VectorXf likelihood(innovations.cols());
+    VectorXd likelihood(innovations.cols());
     bool valid_covariance_matrix;
-    MatrixXf covariance_matrix;
+    MatrixXd covariance_matrix;
     std::tie(valid_covariance_matrix, covariance_matrix) = measurement_model.getNoiseCovarianceMatrix();
 
     if (!valid_covariance_matrix)
-        return std::make_pair(false, VectorXf::Zero(1));
+        return std::make_pair(false, VectorXd::Zero(1));
 
 
     for (unsigned int i = 0; i < innovations.cols(); ++i)
-        likelihood(i) = scale_factor_ * (-0.5 * static_cast<float>(innovations.rows()) * log(2.0*M_PI) - 0.5 * log(covariance_matrix.determinant()) - 0.5 * (innovations.col(i).transpose() * covariance_matrix.inverse() * innovations.col(i)).array()).exp().cast<double>().coeff(0);
+        likelihood(i) = scale_factor_ * (-0.5 * static_cast<double>(innovations.rows()) * log(2.0*M_PI) - 0.5 * log(covariance_matrix.determinant()) - 0.5 * (innovations.col(i).transpose() * covariance_matrix.inverse() * innovations.col(i)).array()).exp().coeff(0);
 
     return std::make_pair(true, likelihood);
 }

--- a/src/BayesFilters/src/HistoryBuffer.cpp
+++ b/src/BayesFilters/src/HistoryBuffer.cpp
@@ -26,7 +26,7 @@ HistoryBuffer& HistoryBuffer::operator=(HistoryBuffer&& history_buffer) noexcept
 }
 
 
-void HistoryBuffer::addElement(const Ref<const VectorXf>& element)
+void HistoryBuffer::addElement(const Ref<const VectorXd>& element)
 {
     history_buffer_.push_front(element);
 
@@ -35,12 +35,12 @@ void HistoryBuffer::addElement(const Ref<const VectorXf>& element)
 }
 
 
-MatrixXf HistoryBuffer::getHistoryBuffer() const
+MatrixXd HistoryBuffer::getHistoryBuffer() const
 {
-    MatrixXf hist_out(7, history_buffer_.size());
+    MatrixXd hist_out(7, history_buffer_.size());
 
     unsigned int i = 0;
-    for (const Ref<const VectorXf>& element : history_buffer_)
+    for (const Ref<const VectorXd>& element : history_buffer_)
         hist_out.col(i++) = element;
 
     return hist_out;

--- a/src/BayesFilters/src/LTIMeasurementModel.cpp
+++ b/src/BayesFilters/src/LTIMeasurementModel.cpp
@@ -6,7 +6,7 @@ using namespace bfl;
 using namespace Eigen;
 
 
-LTIMeasurementModel::LTIMeasurementModel(const Ref<const MatrixXf>& measurement_matrix, const Ref<const MatrixXf>& noise_covariance_matrix)
+LTIMeasurementModel::LTIMeasurementModel(const Ref<const MatrixXd>& measurement_matrix, const Ref<const MatrixXd>& noise_covariance_matrix)
     : H_(measurement_matrix), R_(noise_covariance_matrix)
 {
     if ((H_.rows() == 0) || (H_.cols() == 0))
@@ -20,13 +20,13 @@ LTIMeasurementModel::LTIMeasurementModel(const Ref<const MatrixXf>& measurement_
 }
 
 
-std::pair<bool, Eigen::MatrixXf> LTIMeasurementModel::getNoiseCovarianceMatrix() const
+std::pair<bool, Eigen::MatrixXd> LTIMeasurementModel::getNoiseCovarianceMatrix() const
 {
     return std::make_pair(true, R_);
 }
 
 
-Eigen::MatrixXf LTIMeasurementModel::getMeasurementMatrix() const
+Eigen::MatrixXd LTIMeasurementModel::getMeasurementMatrix() const
 {
     return H_;
 }

--- a/src/BayesFilters/src/LTIStateModel.cpp
+++ b/src/BayesFilters/src/LTIStateModel.cpp
@@ -6,7 +6,7 @@ using namespace bfl;
 using namespace Eigen;
 
 
-LTIStateModel::LTIStateModel(const Ref<const MatrixXf>& transition_matrix, const Ref<const MatrixXf>& noise_covariance_matrix) :
+LTIStateModel::LTIStateModel(const Ref<const MatrixXd>& transition_matrix, const Ref<const MatrixXd>& noise_covariance_matrix) :
     F_(transition_matrix), Q_(noise_covariance_matrix)
 {
     if ((F_.rows() == 0) || (F_.cols() == 0))
@@ -22,19 +22,19 @@ LTIStateModel::LTIStateModel(const Ref<const MatrixXf>& transition_matrix, const
 }
 
 
-void LTIStateModel::propagate(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> prop_states)
+void LTIStateModel::propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> prop_states)
 {
     prop_states = F_ * cur_states;
 }
 
 
-Eigen::MatrixXf LTIStateModel::getNoiseCovarianceMatrix()
+Eigen::MatrixXd LTIStateModel::getNoiseCovarianceMatrix()
 {
     return Q_;
 }
 
 
-Eigen::MatrixXf LTIStateModel::getStateTransitionMatrix()
+Eigen::MatrixXd LTIStateModel::getStateTransitionMatrix()
 {
     return F_;
 }
@@ -46,7 +46,7 @@ bool LTIStateModel::setProperty(const std::string& property)
 }
 
 
-Eigen::MatrixXf LTIStateModel::getJacobian()
+Eigen::MatrixXd LTIStateModel::getJacobian()
 {
     return F_;
 }

--- a/src/BayesFilters/src/LinearMeasurementModel.cpp
+++ b/src/BayesFilters/src/LinearMeasurementModel.cpp
@@ -6,16 +6,16 @@ using namespace bfl;
 using namespace Eigen;
 
 
-std::pair<bool, bfl::Data> LinearMeasurementModel::predictedMeasure(const Eigen::Ref<const Eigen::MatrixXf>& cur_states) const
+std::pair<bool, bfl::Data> LinearMeasurementModel::predictedMeasure(const Eigen::Ref<const Eigen::MatrixXd>& cur_states) const
 {
-    MatrixXf prediction = getMeasurementMatrix() * cur_states;
+    MatrixXd prediction = getMeasurementMatrix() * cur_states;
     return std::make_pair(true, std::move(prediction));
 }
 
 
 std::pair<bool, bfl::Data> LinearMeasurementModel::innovation(const bfl::Data& predicted_measurements, const bfl::Data& measurements) const
 {
-    MatrixXf innovation = -(any::any_cast<MatrixXf>(predicted_measurements).colwise() - any::any_cast<MatrixXf>(measurements).col(0));
+    MatrixXd innovation = -(any::any_cast<MatrixXd>(predicted_measurements).colwise() - any::any_cast<MatrixXd>(measurements).col(0));
 
     return std::make_pair(true, std::move(innovation));
 }

--- a/src/BayesFilters/src/LinearModel.cpp
+++ b/src/BayesFilters/src/LinearModel.cpp
@@ -10,12 +10,12 @@ using namespace Eigen;
 
 LinearModel::LinearModel
 (
-    const float sigma_x,
-    const float sigma_y,
+    const double sigma_x,
+    const double sigma_y,
     const unsigned int seed
 ) noexcept :
     generator_(std::mt19937_64(seed)),
-    distribution_(std::normal_distribution<float>(0.0, 1.0)),
+    distribution_(std::normal_distribution<double>(0.0, 1.0)),
     sigma_x_(sigma_x),
     sigma_y_(sigma_y),
     gauss_rnd_sample_([&] { return (distribution_)(generator_); })
@@ -32,7 +32,7 @@ LinearModel::LinearModel
 }
 
 
-LinearModel::LinearModel(const float sigma_x, const float sigma_y) noexcept :
+LinearModel::LinearModel(const double sigma_x, const double sigma_y) noexcept :
     LinearModel(sigma_x, sigma_y, 1) { }
 
 
@@ -130,25 +130,25 @@ LinearModel& LinearModel::operator=(LinearModel&& lin_sense) noexcept
 }
 
 
-std::pair<bool, MatrixXf> LinearModel::getNoiseSample(const int num) const
+std::pair<bool, MatrixXd> LinearModel::getNoiseSample(const int num) const
 {
-    MatrixXf rand_vectors(2, num);
+    MatrixXd rand_vectors(2, num);
     for (int i = 0; i < rand_vectors.size(); i++)
         *(rand_vectors.data() + i) = gauss_rnd_sample_();
 
-    MatrixXf noise_sample = sqrt_R_ * rand_vectors;
+    MatrixXd noise_sample = sqrt_R_ * rand_vectors;
 
     return std::make_pair(true, std::move(noise_sample));
 }
 
 
-std::pair<bool, MatrixXf> LinearModel::getNoiseCovarianceMatrix() const
+std::pair<bool, MatrixXd> LinearModel::getNoiseCovarianceMatrix() const
 {
     return std::make_pair(true, R_);
 }
 
 
-Eigen::MatrixXf LinearModel::getMeasurementMatrix() const
+Eigen::MatrixXd LinearModel::getMeasurementMatrix() const
 {
     return H_;
 }

--- a/src/BayesFilters/src/LinearStateModel.cpp
+++ b/src/BayesFilters/src/LinearStateModel.cpp
@@ -6,7 +6,7 @@ using namespace bfl;
 using namespace Eigen;
 
 
-void LinearStateModel::propagate(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> pred_states)
+void LinearStateModel::propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> pred_states)
 {
     pred_states = getStateTransitionMatrix() * cur_states;
 }

--- a/src/BayesFilters/src/MeasurementModel.cpp
+++ b/src/BayesFilters/src/MeasurementModel.cpp
@@ -10,9 +10,9 @@ MeasurementModel::~MeasurementModel() noexcept
 { }
 
 
-std::pair<bool, MatrixXf> MeasurementModel::getNoiseCovarianceMatrix() const
+std::pair<bool, MatrixXd> MeasurementModel::getNoiseCovarianceMatrix() const
 {
-    return std::make_pair(false, MatrixXf::Zero(1, 1));
+    return std::make_pair(false, MatrixXd::Zero(1, 1));
 }
 
 

--- a/src/BayesFilters/src/MeasurementModelDecorator.cpp
+++ b/src/BayesFilters/src/MeasurementModelDecorator.cpp
@@ -29,7 +29,7 @@ std::pair<bool, Data> MeasurementModelDecorator::measure() const
 }
 
 
-std::pair<bool, Data> MeasurementModelDecorator::predictedMeasure(const Ref<const MatrixXf>& cur_states) const
+std::pair<bool, Data> MeasurementModelDecorator::predictedMeasure(const Ref<const MatrixXd>& cur_states) const
 {
     return measurement_model->predictedMeasure(cur_states);
 }
@@ -41,7 +41,7 @@ std::pair<bool, Data> MeasurementModelDecorator::innovation(const Data& predicte
 }
 
 
-std::pair<bool, MatrixXf> MeasurementModelDecorator::getNoiseCovarianceMatrix() const
+std::pair<bool, MatrixXd> MeasurementModelDecorator::getNoiseCovarianceMatrix() const
 {
     return measurement_model->getNoiseCovarianceMatrix();
 }

--- a/src/BayesFilters/src/PFCorrectionDecorator.cpp
+++ b/src/BayesFilters/src/PFCorrectionDecorator.cpp
@@ -35,7 +35,7 @@ MeasurementModel& PFCorrectionDecorator::getMeasurementModel()
 }
 
 
-std::pair<bool, VectorXf> PFCorrectionDecorator::getLikelihood()
+std::pair<bool, VectorXd> PFCorrectionDecorator::getLikelihood()
 {
     return correction_->getLikelihood();
 }

--- a/src/BayesFilters/src/Resampling.cpp
+++ b/src/BayesFilters/src/Resampling.cpp
@@ -54,19 +54,19 @@ void Resampling::resample(const ParticleSet& cor_particles, ParticleSet& res_par
                           Ref<VectorXi> res_parents)
 {
     int num_particles = static_cast<int>(cor_particles.weight().rows());
-    VectorXf csw(num_particles);
+    VectorXd csw(num_particles);
 
     csw(0) = cor_particles.weight(0);
     for (int i = 1; i < num_particles; ++i)
         csw(i) = csw(i-1) + cor_particles.weight(i);
 
-    std::uniform_real_distribution<float> distribution_res(0.0, 1.0/num_particles);
-    float u_1 = distribution_res(generator_);
+    std::uniform_real_distribution<double> distribution_res(0.0, 1.0/num_particles);
+    double u_1 = distribution_res(generator_);
 
     int idx_csw = 0;
     for (int j = 0; j < num_particles; ++j)
     {
-        float u_j = u_1 + static_cast<float>(j)/num_particles;
+        double u_j = u_1 + static_cast<double>(j)/num_particles;
 
         while (u_j > csw(idx_csw) && idx_csw < (num_particles - 1))
             idx_csw += 1;
@@ -80,7 +80,7 @@ void Resampling::resample(const ParticleSet& cor_particles, ParticleSet& res_par
 }
 
 
-float Resampling::neff(const Ref<const VectorXf>& cor_weights)
+double Resampling::neff(const Ref<const VectorXd>& cor_weights)
 {
     return 1.0/cor_weights.array().square().sum();
 }

--- a/src/BayesFilters/src/ResamplingWithPrior.cpp
+++ b/src/BayesFilters/src/ResamplingWithPrior.cpp
@@ -63,7 +63,7 @@ void ResamplingWithPrior::resample(const ParticleSet& cor_particles, ParticleSet
     /* Copy particles to be resampled in a temporary. */
     ParticleSet tmp_particles(num_resample_particles, cor_particles.dim_linear, cor_particles.dim_circular);
     int j = 0;
-    for (std::size_t i : sort_indices(cor_particles.weight().cast<float>()))
+    for (std::size_t i : sort_indices(cor_particles.weight()))
     {
         if (j >= num_prior_particles)
         {
@@ -97,7 +97,7 @@ void ResamplingWithPrior::resample(const ParticleSet& cor_particles, ParticleSet
 }
 
 
-std::vector<unsigned int> ResamplingWithPrior::sort_indices(const Ref<const VectorXf>& vector)
+std::vector<unsigned int> ResamplingWithPrior::sort_indices(const Ref<const VectorXd>& vector)
 {
     std::vector<unsigned int> idx(vector.size());
     std::iota(idx.begin(), idx.end(), 0);

--- a/src/BayesFilters/src/SIS.cpp
+++ b/src/BayesFilters/src/SIS.cpp
@@ -66,7 +66,7 @@ void SIS::filteringStep()
            cor_particle_.state().transpose(), cor_particle_.weight().transpose());
 
 
-    if (resampling_->neff(cor_particle_.weight().cast<float>()) < static_cast<float>(num_particle_)/3.0)
+    if (resampling_->neff(cor_particle_.weight()) < static_cast<double>(num_particle_)/3.0)
     {
         ParticleSet res_particle(num_particle_, state_size_);
         VectorXi res_parent(num_particle_, 1);

--- a/src/BayesFilters/src/SPCorrection.cpp
+++ b/src/BayesFilters/src/SPCorrection.cpp
@@ -16,9 +16,9 @@ Gaussian SPCorrection::correct(const Gaussian& pred_state)
 }
 
 
-std::pair<bool, VectorXf> SPCorrection::getLikelihood()
+std::pair<bool, VectorXd> SPCorrection::getLikelihood()
 {
-    return std::make_pair(false, VectorXf::Zero(1));
+    return std::make_pair(false, VectorXd::Zero(1));
 }
 
 

--- a/src/BayesFilters/src/SimulatedLinearSensor.cpp
+++ b/src/BayesFilters/src/SimulatedLinearSensor.cpp
@@ -7,8 +7,8 @@ using namespace Eigen;
 SimulatedLinearSensor::SimulatedLinearSensor
 (
     std::unique_ptr<SimulatedStateModel> simulated_state_model,
-    const float sigma_x,
-    const float sigma_y,
+    const double sigma_x,
+    const double sigma_y,
     const unsigned int seed
 ) :
     LinearModel(sigma_x, sigma_y, seed),
@@ -19,8 +19,8 @@ SimulatedLinearSensor::SimulatedLinearSensor
 SimulatedLinearSensor::SimulatedLinearSensor
 (
      std::unique_ptr<SimulatedStateModel> simulated_state_model,
-     const float sigma_x,
-     const float sigma_y
+     const double sigma_x,
+     const double sigma_y
 ) :
     LinearModel(sigma_x, sigma_y),
     simulated_state_model_(std::move(simulated_state_model))
@@ -42,9 +42,9 @@ bool SimulatedLinearSensor::freezeMeasurements()
     if (!simulated_state_model_->bufferData())
         return false;
 
-    measurement_ = H_ * any::any_cast<MatrixXf>(simulated_state_model_->getData());
+    measurement_ = H_ * any::any_cast<MatrixXd>(simulated_state_model_->getData());
 
-    MatrixXf noise;
+    MatrixXd noise;
     std::tie(std::ignore, noise) = getNoiseSample(measurement_.cols());
 
     measurement_ += noise;

--- a/src/BayesFilters/src/SimulatedStateModel.cpp
+++ b/src/BayesFilters/src/SimulatedStateModel.cpp
@@ -9,13 +9,13 @@ using namespace Eigen;
 SimulatedStateModel::SimulatedStateModel
 (
     std::unique_ptr<StateModel> state_model,
-    const Ref<const VectorXf>& initial_state,
+    const Ref<const VectorXd>& initial_state,
     const unsigned int simulation_time
 ) :
     simulation_time_(simulation_time),
     state_model_(std::move(state_model))
 {
-    target_ = MatrixXf(initial_state.rows(), simulation_time_);
+    target_ = MatrixXd(initial_state.rows(), simulation_time_);
     target_.col(0) = initial_state;
 
     for (int k = 1; k < simulation_time_; ++k)
@@ -33,7 +33,7 @@ bool SimulatedStateModel::bufferData()
 
     logger(target_.col(current_simulation_time_ - 1).transpose());
 
-    MatrixXf process_information = target_.col(current_simulation_time_ - 1);
+    MatrixXd process_information = target_.col(current_simulation_time_ - 1);
 
     data_simulated_state_model_ = std::move(process_information);
 

--- a/src/BayesFilters/src/StateModel.cpp
+++ b/src/BayesFilters/src/StateModel.cpp
@@ -4,13 +4,13 @@ using namespace bfl;
 using namespace Eigen;
 
 
-Eigen::MatrixXf StateModel::getJacobian()
+Eigen::MatrixXd StateModel::getJacobian()
 {
     throw std::runtime_error("ERROR::STATEMODEL::GETJACOBIAN\nERROR:\n\tMethod not implemented.");
 }
 
 
-Eigen::VectorXf StateModel::getTransitionProbability(const Eigen::Ref<const Eigen::MatrixXf>& prev_states, Eigen::Ref<Eigen::MatrixXf> cur_states)
+Eigen::VectorXd StateModel::getTransitionProbability(const Eigen::Ref<const Eigen::MatrixXd>& prev_states, Eigen::Ref<Eigen::MatrixXd> cur_states)
 {
     throw std::runtime_error("ERROR::STATEMODEL::TRANSITIONPROBABILITY\nERROR:\n\tMethod not implemented.");
 }

--- a/src/BayesFilters/src/StateModelDecorator.cpp
+++ b/src/BayesFilters/src/StateModelDecorator.cpp
@@ -23,13 +23,13 @@ StateModelDecorator& StateModelDecorator::operator=(StateModelDecorator&& state_
 }
 
 
-void StateModelDecorator::propagate(const Ref<const MatrixXf>& cur_states, Ref<MatrixXf> prop_states)
+void StateModelDecorator::propagate(const Ref<const MatrixXd>& cur_states, Ref<MatrixXd> prop_states)
 {
     state_model_->propagate(cur_states, prop_states);
 }
 
 
-void StateModelDecorator::motion(const Ref<const MatrixXf>& cur_states, Ref<MatrixXf> mot_states)
+void StateModelDecorator::motion(const Ref<const MatrixXd>& cur_states, Ref<MatrixXd> mot_states)
 {
     state_model_->motion(cur_states, mot_states);
 }

--- a/src/BayesFilters/src/UpdateParticles.cpp
+++ b/src/BayesFilters/src/UpdateParticles.cpp
@@ -15,16 +15,16 @@ UpdateParticles::~UpdateParticles() noexcept { }
 
 void UpdateParticles::correctStep(const ParticleSet& pred_particles, ParticleSet& cor_particles)
 {
-    std::tie(valid_likelihood_, likelihood_) = likelihood_model_->likelihood(*measurement_model_, pred_particles.state().cast<float>());
+    std::tie(valid_likelihood_, likelihood_) = likelihood_model_->likelihood(*measurement_model_, pred_particles.state());
     
     cor_particles = pred_particles;
 
     if (valid_likelihood_)
-        cor_particles.weight() = cor_particles.weight().cwiseProduct(likelihood_.cast<double>());
+        cor_particles.weight() = cor_particles.weight().cwiseProduct(likelihood_);
 }
 
 
-std::pair<bool, VectorXf> UpdateParticles::getLikelihood()
+std::pair<bool, VectorXd> UpdateParticles::getLikelihood()
 {
     return std::make_pair(valid_likelihood_, likelihood_);
 }

--- a/src/BayesFilters/src/WhiteNoiseAcceleration.cpp
+++ b/src/BayesFilters/src/WhiteNoiseAcceleration.cpp
@@ -11,12 +11,12 @@ using namespace Eigen;
 
 WhiteNoiseAcceleration::WhiteNoiseAcceleration
 (
-    float T,
-    float tilde_q,
+    double T,
+    double tilde_q,
     unsigned int seed
 ) noexcept :
     generator_(std::mt19937_64(seed)),
-    distribution_(std::normal_distribution<float>(0.0, 1.0)),
+    distribution_(std::normal_distribution<double>(0.0, 1.0)),
     T_(T),
     tilde_q_(tilde_q),
     gauss_rnd_sample_([&] { return (distribution_)(generator_); })
@@ -26,20 +26,20 @@ WhiteNoiseAcceleration::WhiteNoiseAcceleration
           0.0, 0.0, 1.0,  T_,
           0.0, 0.0, 0.0, 1.0;
 
-    float q11 = 1.0/3.0 * std::pow(T_, 3.0);
-    float q2  = 1.0/2.0 * std::pow(T_, 2.0);
+    double q11 = 1.0/3.0 * std::pow(T_, 3.0);
+    double q2  = 1.0/2.0 * std::pow(T_, 2.0);
     Q_ << q11,  q2, 0.0, 0.0,
            q2,  T_, 0.0, 0.0,
           0.0, 0.0, q11,  q2,
           0.0, 0.0,  q2,  T_;
     Q_ *= tilde_q;
 
-    LDLT<Matrix4f> chol_ldlt(Q_);
-    sqrt_Q_ = (chol_ldlt.transpositionsP() * Matrix4f::Identity()).transpose() * chol_ldlt.matrixL() * chol_ldlt.vectorD().real().cwiseSqrt().asDiagonal();
+    LDLT<Matrix4d> chol_ldlt(Q_);
+    sqrt_Q_ = (chol_ldlt.transpositionsP() * Matrix4d::Identity()).transpose() * chol_ldlt.matrixL() * chol_ldlt.vectorD().real().cwiseSqrt().asDiagonal();
 }
 
 
-WhiteNoiseAcceleration::WhiteNoiseAcceleration(float T, float tilde_q) noexcept :
+WhiteNoiseAcceleration::WhiteNoiseAcceleration(double T, double tilde_q) noexcept :
     WhiteNoiseAcceleration(T, tilde_q, 1)
 { }
 
@@ -108,9 +108,9 @@ WhiteNoiseAcceleration& WhiteNoiseAcceleration::operator=(WhiteNoiseAcceleration
 }
 
 
-MatrixXf WhiteNoiseAcceleration::getNoiseSample(const std::size_t num)
+MatrixXd WhiteNoiseAcceleration::getNoiseSample(const std::size_t num)
 {
-    MatrixXf rand_vectors(4, num);
+    MatrixXd rand_vectors(4, num);
     for (int i = 0; i < rand_vectors.size(); i++)
         *(rand_vectors.data() + i) = gauss_rnd_sample_();
 
@@ -118,13 +118,13 @@ MatrixXf WhiteNoiseAcceleration::getNoiseSample(const std::size_t num)
 }
 
 
-MatrixXf WhiteNoiseAcceleration::getNoiseCovarianceMatrix()
+MatrixXd WhiteNoiseAcceleration::getNoiseCovarianceMatrix()
 {
     return Q_;
 }
 
 
-MatrixXf WhiteNoiseAcceleration::getStateTransitionMatrix()
+MatrixXd WhiteNoiseAcceleration::getStateTransitionMatrix()
 {
     return F_;
 }

--- a/src/BayesFilters/src/sigma_point.cpp
+++ b/src/BayesFilters/src/sigma_point.cpp
@@ -92,14 +92,14 @@ std::tuple<bool, GaussianMixture, MatrixXd> bfl::sigma_point::unscented_transfor
     /* Propagate sigma points */
     Data fun_data;
     bool valid_fun_data;
-    std::tie(valid_fun_data, fun_data) = function(input_sigma_points.cast<float>());
+    std::tie(valid_fun_data, fun_data) = function(input_sigma_points);
 
     /* Stop here if function evaluation failed. */
     if (!valid_fun_data)
         return std::make_tuple(false, GaussianMixture(), MatrixXd(0, 0));
 
     /* For now casting Data to MatrixXd. */
-    MatrixXd prop_sigma_points = (bfl::any::any_cast<MatrixXf&&>(std::move(fun_data))).cast<double>();
+    MatrixXd prop_sigma_points = bfl::any::any_cast<MatrixXd&&>(std::move(fun_data));
 
     /* Initialize transformed gaussian. */
     GaussianMixture output(input.components, prop_sigma_points.rows());
@@ -138,9 +138,9 @@ std::pair<GaussianMixture, MatrixXd> bfl::sigma_point::unscented_transform
     StateModel& state_model
 )
 {
-    FunctionEvaluation f = [&state_model](const Ref<const MatrixXf>& state)
+    FunctionEvaluation f = [&state_model](const Ref<const MatrixXd>& state)
                            {
-                               MatrixXf tmp(state.rows(), state.cols());
+                               MatrixXd tmp(state.rows(), state.cols());
                                
                                state_model.motion(state, tmp);
                                
@@ -162,12 +162,12 @@ std::pair<GaussianMixture, MatrixXd> bfl::sigma_point::unscented_transform
     ExogenousModel& exogenous_model
 )
 {
-    FunctionEvaluation f = [&state_model, &exogenous_model](const Ref<const MatrixXf>& state)
+    FunctionEvaluation f = [&state_model, &exogenous_model](const Ref<const MatrixXd>& state)
                            {
-                               MatrixXf tmp_state(state.rows(), state.cols());
+                               MatrixXd tmp_state(state.rows(), state.cols());
                                state_model.motion(state, tmp_state);
 
-                               MatrixXf tmp_exog(tmp_state.rows(), tmp_state.cols());
+                               MatrixXd tmp_exog(tmp_state.rows(), tmp_state.cols());
                                exogenous_model.propagate(tmp_state, tmp_exog);
                                
                                return std::make_pair(true, std::move(tmp_exog));
@@ -187,9 +187,9 @@ std::pair<GaussianMixture, MatrixXd> bfl::sigma_point::unscented_transform
     AdditiveStateModel& state_model
 )
 {
-    FunctionEvaluation f = [&state_model](const Ref<const MatrixXf>& state)
+    FunctionEvaluation f = [&state_model](const Ref<const MatrixXd>& state)
                            {
-                               MatrixXf tmp(state.rows(), state.cols());
+                               MatrixXd tmp(state.rows(), state.cols());
                                
                                state_model.propagate(state, tmp);
                                
@@ -203,7 +203,7 @@ std::pair<GaussianMixture, MatrixXd> bfl::sigma_point::unscented_transform
     /* In the additive case the covariance matrix is augmented with the noise
        covariance matrix. */
     for(std::size_t i = 0; i < state.components; i++)
-        output.covariance(i) += state_model.getNoiseCovarianceMatrix().cast<double>();
+        output.covariance(i) += state_model.getNoiseCovarianceMatrix();
 
     return std::make_pair(output, cross_covariance);
 }
@@ -217,12 +217,12 @@ std::pair<GaussianMixture, MatrixXd> bfl::sigma_point::unscented_transform
     ExogenousModel& exogenous_model
 )
 {
-    FunctionEvaluation f = [&state_model, &exogenous_model](const Ref<const MatrixXf>& state)
+    FunctionEvaluation f = [&state_model, &exogenous_model](const Ref<const MatrixXd>& state)
                            {
-                               MatrixXf tmp_state(state.rows(), state.cols());
+                               MatrixXd tmp_state(state.rows(), state.cols());
                                state_model.propagate(state, tmp_state);
 
-                               MatrixXf tmp_exog(tmp_state.rows(), tmp_state.cols());
+                               MatrixXd tmp_exog(tmp_state.rows(), tmp_state.cols());
                                exogenous_model.propagate(tmp_state, tmp_exog);
 
                                return std::make_pair(true, std::move(tmp_exog));
@@ -236,7 +236,7 @@ std::pair<GaussianMixture, MatrixXd> bfl::sigma_point::unscented_transform
     /* In the additive case the covariance matrix is augmented with the noise
        covariance matrix. */
     for (std::size_t i = 0; i < state.components; i++)
-        output.covariance(i) += state_model.getNoiseCovarianceMatrix().cast<double>();
+        output.covariance(i) += state_model.getNoiseCovarianceMatrix();
 
     return std::make_pair(output, cross_covariance);
 }
@@ -249,9 +249,9 @@ std::pair<GaussianMixture, MatrixXd> bfl::sigma_point::unscented_transform
     ExogenousModel& exogenous_model
 )
 {
-    FunctionEvaluation f = [&exogenous_model](const Ref<const MatrixXf>& state)
+    FunctionEvaluation f = [&exogenous_model](const Ref<const MatrixXd>& state)
                            {
-                               MatrixXf tmp(state.rows(), state.cols());
+                               MatrixXd tmp(state.rows(), state.cols());
                                
                                exogenous_model.propagate(state, tmp);
                                
@@ -274,7 +274,7 @@ std::tuple<bool, GaussianMixture, MatrixXd> bfl::sigma_point::unscented_transfor
     MeasurementModel& meas_model
 )
 {
-    FunctionEvaluation f = [&meas_model](const Ref<const MatrixXf>& state)
+    FunctionEvaluation f = [&meas_model](const Ref<const MatrixXd>& state)
                            {
                                return meas_model.predictedMeasure(state);
                            };
@@ -295,7 +295,7 @@ std::tuple<bool, GaussianMixture, MatrixXd> bfl::sigma_point::unscented_transfor
     LinearMeasurementModel& meas_model
 )
 {
-    FunctionEvaluation f = [&meas_model](const Ref<const MatrixXf>& state)
+    FunctionEvaluation f = [&meas_model](const Ref<const MatrixXd>& state)
                            {
                                return meas_model.predictedMeasure(state);
                            };
@@ -307,10 +307,10 @@ std::tuple<bool, GaussianMixture, MatrixXd> bfl::sigma_point::unscented_transfor
 
     /* In the additive case the covariance matrix is augmented with the noise
        covariance matrix. */
-    MatrixXf noise_cov;
+    MatrixXd noise_cov;
     std::tie(std::ignore, noise_cov) = meas_model.getNoiseCovarianceMatrix();
     for (std::size_t i = 0; i < state.components; i++)
-        output.covariance(i) += noise_cov.cast<double>();
+        output.covariance(i) += noise_cov;
 
     return std::make_tuple(valid, output, cross_covariance);
 }

--- a/test/test_SIS/main.cpp
+++ b/test/test_SIS/main.cpp
@@ -50,7 +50,7 @@ int main()
     unsigned int num_particle_x = 100;
     unsigned int num_particle_y = 100;
     unsigned int num_particle = num_particle_x * num_particle_y;
-    Vector4f initial_state(10.0f, 0.0f, 10.0f, 0.0f);
+    Vector4d initial_state(10.0f, 0.0f, 10.0f, 0.0f);
     unsigned int simulation_time = 100;
     std::size_t state_size = 4;
 
@@ -62,8 +62,8 @@ int main()
     /* Step 2 - Prediction */
     /* Step 2.1 - Define the state model */
     /* Initialize a white noise acceleration state model. */
-    float T = 1.0f;
-    float tilde_q = 10.0f;
+    double T = 1.0f;
+    double tilde_q = 10.0f;
 
     std::unique_ptr<StateModel> wna = utils::make_unique<WhiteNoiseAcceleration>(T, tilde_q);
 

--- a/test/test_SIS_Decorators/main.cpp
+++ b/test/test_SIS_Decorators/main.cpp
@@ -33,7 +33,7 @@ public:
     { };
 
 
-    void motion(const Eigen::Ref<const Eigen::MatrixXf>& cur_states, Eigen::Ref<Eigen::MatrixXf> mot_states) override
+    void motion(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> mot_states) override
     {
         std::cout << "Decorator: DecoratedWNA::motion()." << std::endl;
 
@@ -123,7 +123,7 @@ int main()
     unsigned int num_particle_x = 100;
     unsigned int num_particle_y = 100;
     unsigned int num_particle = num_particle_x * num_particle_y;
-    Vector4f initial_state(10.0f, 0.0f, 10.0f, 0.0f);
+    Vector4d initial_state(10.0f, 0.0f, 10.0f, 0.0f);
     unsigned int simulation_time = 10;
     std::size_t state_size = 4;
 


### PR DESCRIPTION
Within this PR:
- changed every occurrence of `Eigen::Matrix*f` to `Eigen::Matrix*d`
- changed every occurrence of `Eigen::Vector*f` to `Eigen::Vector*d`
- changed every occurrence of `float` to `double`
- removed unnecessary `cast<float>()` and `cast<double>()`
- updated  `CHANGELOG.md`

The main rationale behind this change is to avoid problems with methods taking `Eigen::Ref` as input argument. When the input data require casting, `Eigen::Ref` cannot wrap casted data obtained with `cast<>()` and it is required to copy casted data to temporary objects before passing it to the function.
