### PR TITLE
Improve state and measurement models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,25 +32,27 @@
 
 ###### State models
  - Added SimulatedStateModel class to simulate kinematic or dynamic models using StateModel classes.
- - Removed method StateModel::getNoiseCovarianceMatrix.
- - Removed method StateModel::getNoiseSample.
- - Removed method StateModelDecorator::getNoiseCovarianceMatrix.
- - Removed method StateModelDecorator::getNoiseSample.
  - Added non-pure virtual method StateModel::getTransitionProbability.
  - Added non-pure virtual method StateModel::getJacobian.
+ - Added pure virtual method StateModel::getOutputSize
+ - Added pure virtual method ExogenousModel::getOutputSize
+ - Implemented method StateModelDecorator::getOutputSize
  - Implemented AdditiveStateModel class inheriting from StateModel.
  - Implemented LinearStateModel class inheriting from AdditiveStateModel.
  - Implemented LTIStateModel class inheriting from LinearStateModel.
  - WhiteNoiseAcceleration class now inherits from LinearStateModel.
+ - Implemented method WhiteNoiseAcceleration::getOutputSize
 
 ###### Measurement models
  - Added SimulatedLinearSensor class.
  - Added MeasurementModelDecorator class.
  - Added logging capabilities to MeasurementModel.
  - Removed method MeasurementModel::getNoiseSample.
+ - Added pure virtual method MeasurementModel::getOutputSize
  - Method MeasurementModel::measure replaces method MeasurementModel::getAgentMeasurements and does not take the state as input.
  - Method MeasurementModel::freezeMeasurements replaces method MeasurementModel::bufferAgentData const.
  - Method UpdateParticles::correctStep uses MeasurementModel::freezeMeasurements.
+ - Added class AdditiveMeasurementModel.
  - Added class LinearMeasurementModel.
  - Added class LTIMeasurementModel.
  - Renamed LinearSensor to LinearModel.

--- a/src/BayesFilters/CMakeLists.txt
+++ b/src/BayesFilters/CMakeLists.txt
@@ -14,6 +14,7 @@ set(${LIBRARY_TARGET_NAME}_FA_HDR
 )
 
 set(${LIBRARY_TARGET_NAME}_FF_HDR
+        include/BayesFilters/AdditiveMeasurementModel.h
         include/BayesFilters/AdditiveStateModel.h
         include/BayesFilters/Agent.h
         include/BayesFilters/AuxiliaryFunction.h
@@ -84,6 +85,7 @@ set(${LIBRARY_TARGET_NAME}_FA_SRC
 )
 
 set(${LIBRARY_TARGET_NAME}_FF_SRC
+        src/AdditiveMeasurementModel.cpp
         src/AdditiveStateModel.cpp
         src/Agent.cpp
         src/AuxiliaryFunction.cpp

--- a/src/BayesFilters/include/BayesFilters/AdditiveMeasurementModel.h
+++ b/src/BayesFilters/include/BayesFilters/AdditiveMeasurementModel.h
@@ -1,0 +1,17 @@
+#ifndef ADDITIVEMEASUREMENTMODEL_H
+#define ADDITIVEMEASUREMENTMODEL_H
+
+#include <BayesFilters/MeasurementModel.h>
+
+namespace bfl {
+    class AdditiveMeasurementModel;
+}
+
+
+class bfl::AdditiveMeasurementModel : public bfl::MeasurementModel
+{
+public:
+    virtual ~AdditiveMeasurementModel() noexcept;
+};
+
+#endif /* ADDITIVEMEASUREMENTMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/AdditiveStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/AdditiveStateModel.h
@@ -17,8 +17,6 @@ public:
 
     virtual void motion(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> mot_states) override;
 
-    virtual Eigen::MatrixXd getNoiseCovarianceMatrix() = 0;
-
     virtual Eigen::MatrixXd getNoiseSample(const std::size_t num) = 0;
 };
 

--- a/src/BayesFilters/include/BayesFilters/AdditiveStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/AdditiveStateModel.h
@@ -16,8 +16,6 @@ public:
     virtual ~AdditiveStateModel() noexcept { };
 
     virtual void motion(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> mot_states) override;
-
-    virtual Eigen::MatrixXd getNoiseSample(const std::size_t num) = 0;
 };
 
 #endif /* ADDITIVESTATEMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/ExogenousModel.h
+++ b/src/BayesFilters/include/BayesFilters/ExogenousModel.h
@@ -18,6 +18,8 @@ public:
     virtual Eigen::MatrixXd getExogenousMatrix() = 0;
 
     virtual bool setProperty(const std::string& property) = 0;
+
+    virtual std::pair<std::size_t, std::size_t> getOutputSize() const = 0;
 };
 
 #endif /* EXOGENOUSMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/LinearMeasurementModel.h
+++ b/src/BayesFilters/include/BayesFilters/LinearMeasurementModel.h
@@ -1,7 +1,7 @@
 #ifndef LINEARMEMEASUREMENTMODEL_H
 #define LINEARMEMEASUREMENTMODEL_H
 
-#include <BayesFilters/MeasurementModel.h>
+#include <BayesFilters/AdditiveMeasurementModel.h>
 
 #include <Eigen/Dense>
 
@@ -10,7 +10,7 @@ namespace bfl {
 }
 
 
-class bfl::LinearMeasurementModel : public MeasurementModel
+class bfl::LinearMeasurementModel : public bfl::AdditiveMeasurementModel
 {
 public:
     virtual ~LinearMeasurementModel() noexcept { };

--- a/src/BayesFilters/include/BayesFilters/MeasurementModel.h
+++ b/src/BayesFilters/include/BayesFilters/MeasurementModel.h
@@ -31,6 +31,9 @@ public:
     virtual bool setProperty(const std::string& property);
 
     virtual bool freezeMeasurements() = 0;
+
+    /* Returns the linear and circular size of the output of the measurement equation. */
+    virtual std::pair<std::size_t, std::size_t> getOutputSize() const = 0;
 };
 
 #endif /* MEASUREMENTMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/MeasurementModelDecorator.h
+++ b/src/BayesFilters/include/BayesFilters/MeasurementModelDecorator.h
@@ -25,6 +25,8 @@ public:
 
     bool freezeMeasurements() override;
 
+    std::pair<std::size_t, std::size_t> getOutputSize() const override;
+
 protected:
     MeasurementModelDecorator(std::unique_ptr<MeasurementModel> measurement_model) noexcept;
 

--- a/src/BayesFilters/include/BayesFilters/SimulatedLinearSensor.h
+++ b/src/BayesFilters/include/BayesFilters/SimulatedLinearSensor.h
@@ -26,10 +26,16 @@ public:
 
     std::pair<bool, bfl::Data> measure() const override;
 
+    std::pair<std::size_t, std::size_t> getOutputSize() const override;
+
 protected:
     std::unique_ptr<bfl::SimulatedStateModel> simulated_state_model_;
 
     Eigen::MatrixXd measurement_;
+
+    std::size_t dim_linear_;
+
+    std::size_t dim_circular_;
 };
 
 #endif /* SIMULATEDLINEARSENSOR_H */

--- a/src/BayesFilters/include/BayesFilters/SimulatedStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/SimulatedStateModel.h
@@ -26,6 +26,8 @@ public:
 
     bool setProperty(const std::string& property) override;
 
+    StateModel& getStateModel();
+
 private:
     unsigned int simulation_time_;
 

--- a/src/BayesFilters/include/BayesFilters/StateModel.h
+++ b/src/BayesFilters/include/BayesFilters/StateModel.h
@@ -23,6 +23,8 @@ public:
 
     virtual Eigen::MatrixXd getNoiseCovarianceMatrix();
 
+    virtual Eigen::MatrixXd getNoiseSample(const std::size_t num);
+
     virtual bool setProperty(const std::string& property) = 0;
 };
 

--- a/src/BayesFilters/include/BayesFilters/StateModel.h
+++ b/src/BayesFilters/include/BayesFilters/StateModel.h
@@ -21,6 +21,8 @@ public:
 
     virtual Eigen::VectorXd getTransitionProbability(const Eigen::Ref<const Eigen::MatrixXd>& prev_states, Eigen::Ref<Eigen::MatrixXd> cur_states);
 
+    virtual Eigen::MatrixXd getNoiseCovarianceMatrix();
+
     virtual bool setProperty(const std::string& property) = 0;
 };
 

--- a/src/BayesFilters/include/BayesFilters/StateModel.h
+++ b/src/BayesFilters/include/BayesFilters/StateModel.h
@@ -26,6 +26,11 @@ public:
     virtual Eigen::MatrixXd getNoiseSample(const std::size_t num);
 
     virtual bool setProperty(const std::string& property) = 0;
+
+    /**
+     * Returns the linear and circular size of the output of the state equation.
+     */
+    virtual std::pair<std::size_t, std::size_t> getOutputSize() const = 0;
 };
 
 #endif /* STATEMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/StateModelDecorator.h
+++ b/src/BayesFilters/include/BayesFilters/StateModelDecorator.h
@@ -19,6 +19,8 @@ public:
 
     bool setProperty(const std::string& property) override;
 
+    Eigen::MatrixXd getNoiseCovarianceMatrix() override;
+
 protected:
     StateModelDecorator(std::unique_ptr<StateModel> state_model) noexcept;
 

--- a/src/BayesFilters/include/BayesFilters/StateModelDecorator.h
+++ b/src/BayesFilters/include/BayesFilters/StateModelDecorator.h
@@ -21,6 +21,8 @@ public:
 
     Eigen::MatrixXd getNoiseCovarianceMatrix() override;
 
+    Eigen::MatrixXd getNoiseSample(const std::size_t num) override;
+
 protected:
     StateModelDecorator(std::unique_ptr<StateModel> state_model) noexcept;
 

--- a/src/BayesFilters/include/BayesFilters/StateModelDecorator.h
+++ b/src/BayesFilters/include/BayesFilters/StateModelDecorator.h
@@ -23,6 +23,8 @@ public:
 
     Eigen::MatrixXd getNoiseSample(const std::size_t num) override;
 
+    std::pair<std::size_t, std::size_t> getOutputSize() const override;
+
 protected:
     StateModelDecorator(std::unique_ptr<StateModel> state_model) noexcept;
 

--- a/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
+++ b/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
@@ -38,6 +38,8 @@ public:
 
     bool setProperty(const std::string& property) override { return false; };
 
+    std::pair<std::size_t, std::size_t> getOutputSize() const override;
+
 private:
     std::mt19937_64 generator_;
 

--- a/src/BayesFilters/src/AdditiveMeasurementModel.cpp
+++ b/src/BayesFilters/src/AdditiveMeasurementModel.cpp
@@ -1,0 +1,6 @@
+#include <BayesFilters/AdditiveMeasurementModel.h>
+
+using namespace bfl;
+
+AdditiveMeasurementModel::~AdditiveMeasurementModel() noexcept
+{ }

--- a/src/BayesFilters/src/MeasurementModelDecorator.cpp
+++ b/src/BayesFilters/src/MeasurementModelDecorator.cpp
@@ -57,3 +57,9 @@ bool MeasurementModelDecorator::freezeMeasurements()
 {
     return measurement_model->freezeMeasurements();
 }
+
+
+std::pair<std::size_t, std::size_t> MeasurementModelDecorator::getOutputSize() const
+{
+    return measurement_model->getOutputSize();
+}

--- a/src/BayesFilters/src/SimulatedLinearSensor.cpp
+++ b/src/BayesFilters/src/SimulatedLinearSensor.cpp
@@ -13,7 +13,28 @@ SimulatedLinearSensor::SimulatedLinearSensor
 ) :
     LinearModel(sigma_x, sigma_y, seed),
     simulated_state_model_(std::move(simulated_state_model))
-{ }
+{
+    /* Since a LinearSensor is intended as a sensor that measure
+       the state directly (i.e. no linear combination of the states),
+       then it is possible to extract the output size from the
+       output size of the simulated state model. */
+    std::size_t dim_linear_state;
+    std::size_t dim_circular_state;
+    std::tie(dim_linear_state, dim_circular_state) = simulated_state_model_->getStateModel().getOutputSize();
+
+    dim_linear_ = 0;
+    dim_circular_ = 0;
+
+    for (std::size_t i = 0; i < H_.rows(); i++)
+    {
+        Eigen::MatrixXf::Index state_index;
+        H_.row(i).array().abs().maxCoeff(&state_index);
+        if (state_index < dim_linear_state)
+            dim_linear_++;
+        else
+            dim_circular_++;
+    }
+}
 
 
 SimulatedLinearSensor::SimulatedLinearSensor
@@ -22,14 +43,12 @@ SimulatedLinearSensor::SimulatedLinearSensor
      const double sigma_x,
      const double sigma_y
 ) :
-    LinearModel(sigma_x, sigma_y),
-    simulated_state_model_(std::move(simulated_state_model))
+    SimulatedLinearSensor(std::move(simulated_state_model), sigma_x, sigma_y, 1)
 { }
 
 
 SimulatedLinearSensor::SimulatedLinearSensor(std::unique_ptr<SimulatedStateModel> simulated_state_model) :
-    LinearModel(),
-    simulated_state_model_(std::move(simulated_state_model))
+    SimulatedLinearSensor(std::move(simulated_state_model), 10.0, 10.0, 1)
 { }
 
 
@@ -58,4 +77,10 @@ bool SimulatedLinearSensor::freezeMeasurements()
 std::pair<bool, Data> SimulatedLinearSensor::measure() const
 {
     return std::make_pair(true, measurement_);
+}
+
+
+std::pair<std::size_t, std::size_t> SimulatedLinearSensor::getOutputSize() const
+{
+    return std::make_pair(dim_linear_, dim_circular_);
 }

--- a/src/BayesFilters/src/SimulatedStateModel.cpp
+++ b/src/BayesFilters/src/SimulatedStateModel.cpp
@@ -59,3 +59,9 @@ bool SimulatedStateModel::setProperty(const std::string& property)
 
     return false;
 }
+
+
+StateModel& SimulatedStateModel::getStateModel()
+{
+    return *state_model_;
+}

--- a/src/BayesFilters/src/StateModel.cpp
+++ b/src/BayesFilters/src/StateModel.cpp
@@ -14,3 +14,9 @@ Eigen::VectorXd StateModel::getTransitionProbability(const Eigen::Ref<const Eige
 {
     throw std::runtime_error("ERROR::STATEMODEL::TRANSITIONPROBABILITY\nERROR:\n\tMethod not implemented.");
 }
+
+
+Eigen::MatrixXd StateModel::getNoiseCovarianceMatrix()
+{
+    throw std::runtime_error("ERROR::STATEMODEL::GETNOISECOVARIANCEMATRIX\nERROR:\n\tMethod not implemented.");
+}

--- a/src/BayesFilters/src/StateModel.cpp
+++ b/src/BayesFilters/src/StateModel.cpp
@@ -20,3 +20,9 @@ Eigen::MatrixXd StateModel::getNoiseCovarianceMatrix()
 {
     throw std::runtime_error("ERROR::STATEMODEL::GETNOISECOVARIANCEMATRIX\nERROR:\n\tMethod not implemented.");
 }
+
+
+Eigen::MatrixXd StateModel::getNoiseSample(const std::size_t num)
+{
+    throw std::runtime_error("ERROR::STATEMODEL::GETNOISESAMPLE\nERROR:\n\tMethod not implemented.");
+}

--- a/src/BayesFilters/src/StateModelDecorator.cpp
+++ b/src/BayesFilters/src/StateModelDecorator.cpp
@@ -45,3 +45,9 @@ MatrixXd StateModelDecorator::getNoiseCovarianceMatrix()
 {
     return state_model_->getNoiseCovarianceMatrix();
 }
+
+
+MatrixXd StateModelDecorator::getNoiseSample(const std::size_t num)
+{
+    return state_model_->getNoiseSample(num);
+}

--- a/src/BayesFilters/src/StateModelDecorator.cpp
+++ b/src/BayesFilters/src/StateModelDecorator.cpp
@@ -51,3 +51,9 @@ MatrixXd StateModelDecorator::getNoiseSample(const std::size_t num)
 {
     return state_model_->getNoiseSample(num);
 }
+
+
+std::pair<std::size_t, std::size_t> StateModelDecorator::getOutputSize() const
+{
+    return state_model_->getOutputSize();
+}

--- a/src/BayesFilters/src/StateModelDecorator.cpp
+++ b/src/BayesFilters/src/StateModelDecorator.cpp
@@ -39,3 +39,9 @@ bool StateModelDecorator::setProperty(const std::string& property)
 {
     return state_model_->setProperty(property);
 }
+
+
+MatrixXd StateModelDecorator::getNoiseCovarianceMatrix()
+{
+    return state_model_->getNoiseCovarianceMatrix();
+}

--- a/src/BayesFilters/src/WhiteNoiseAcceleration.cpp
+++ b/src/BayesFilters/src/WhiteNoiseAcceleration.cpp
@@ -128,3 +128,9 @@ MatrixXd WhiteNoiseAcceleration::getStateTransitionMatrix()
 {
     return F_;
 }
+
+
+std::pair<std::size_t, std::size_t> WhiteNoiseAcceleration::getOutputSize() const
+{
+    return std::make_pair(4, 0);
+}


### PR DESCRIPTION
Within this PR:
#### Measurement models
- Added class `AdditiveMeasurementModel` inheriting from `MeasurementModel`
- Class `LinearMeasurementModel` now inherits from class `AdditiveMeasurementModel`
- Added pure virtual method `MeasurementModel::getOutputSize` returning the number of output linear measurements and the number of output circular measurements
- Implemented method `SimulatedLinearSensor::getOutputSize`

#### State models:
- Moved pure virtual method `AdditiveStateModel::getNoiseCovarianceMatrix` to class `StateModel` as a non-pure virtual method
- Moved pure virtual method `AddiviteStateModel::getNoiseSample` to class `StateModel` as a non-pure virtual method
- Added pure virtual method `StateModel::getOutputSize` returning the number of linear output states and the number of output circular states
- Added pure virtual method `ExogenousModel::getOutputSize` returning the number of output linear states and the number of output circular states
- Implemented method `WhiteNoiseAcceleration::getOutputSize`
- Implemented method `SimulatedStateModel::getStateModel` required to implement `SimulatedLinearSensor::getOutputSize`

**Note:** method regarding noise generation and noise covariance are now in the base classes `StateModel` and `MeasurementModel`. The rationale behind this is that the noise affecting any process model and any measurement model is assumed to be Gaussian with zero mean and given covariance. This without loss of generality because the noise can be transformed into any other kind of noise inside the nonlinear models.

#### Changelog:
- Updated CHANGELOG.md

This closes hsp-iit/workbook-nicola-piga#47