### PR TITLE
Improve directional_statistics

### DIFF
--- a/src/BayesFilters/include/BayesFilters/directional_statistics.h
+++ b/src/BayesFilters/include/BayesFilters/directional_statistics.h
@@ -13,7 +13,7 @@ namespace directional_statistics
 
     Eigen::MatrixXd directional_sub(const Eigen::Ref<const Eigen::MatrixXd>& a, const Eigen::Ref<const Eigen::VectorXd>& b);
 
-    double directional_mean(const Eigen::Ref<const Eigen::VectorXd>& a, const Eigen::Ref<const Eigen::VectorXd>& w);
+    Eigen::VectorXd directional_mean(const Eigen::Ref<const Eigen::MatrixXd>& a, const Eigen::Ref<const Eigen::VectorXd>& w);
 
 }
 }

--- a/src/BayesFilters/src/directional_statistics.cpp
+++ b/src/BayesFilters/src/directional_statistics.cpp
@@ -22,13 +22,14 @@ MatrixXd bfl::directional_statistics::directional_sub(const Ref<const MatrixXd>&
 }
 
 
-double bfl::directional_statistics::directional_mean(const Ref<const VectorXd>& a, const Ref<const VectorXd>& w)
+VectorXd bfl::directional_statistics::directional_mean(const Ref<const MatrixXd>& a, const Ref<const VectorXd>& w)
 {
-    MatrixXcd complex_a(a.rows(), a.cols());
-
-    complex_a.imag() = a;
-
-    std::complex<double> phasor = (w.array() * complex_a.array().exp()).sum();
-
-    return std::atan2(phasor.imag(), phasor.real());
+    /* If one column only is provided, it is returned as is. */
+    if (a.cols() == 1)
+        return a.col(0);
+    
+    /* For each row i of the matrix a,
+       the method computes the sum of exponentials sum(w_{k} * e^(j*a_{ik})) where j is the imaginary unit
+       and then extract the phase angle using the method arg(x). */
+   return ((std::complex<double>(0.0, 1.0) * a).array().exp().matrix() * w).array().arg();
 }

--- a/src/BayesFilters/src/directional_statistics.cpp
+++ b/src/BayesFilters/src/directional_statistics.cpp
@@ -9,18 +9,10 @@ using namespace Eigen;
 
 MatrixXd bfl::directional_statistics::directional_add(const Ref<const MatrixXd>& a, const Ref<const VectorXd>& b)
 {
-    MatrixXd result = a.colwise() + b;
-
-    for (unsigned int i = 0; i < result.rows(); ++i)
-    {
-        for (unsigned int j = 0; j < result.cols(); ++j)
-        {
-            if      (result(i, j) >   M_PI) result(i, j) -= 2.0 * M_PI;
-            else if (result(i, j) <= -M_PI) result(i, j) += 2.0 * M_PI;
-        }
-    }
-
-    return result;
+    /* Let M = a.colwise() + b.
+       Then Mij = arg(exp(j * Mij)) where j is the imaginary unit
+       and arg(x) is the phase angle of the complex number x. */
+    return (std::complex<double>(0.0, 1.0) * (a.colwise() + b)).array().exp().arg();
 }
 
 

--- a/test/test_DirectionalStatisticsUtils/main.cpp
+++ b/test/test_DirectionalStatisticsUtils/main.cpp
@@ -67,24 +67,46 @@ int main()
     std::cout << "Running directional mean...\n" << std::endl;
 
 
-    std::cout << "With Vector2d:\n" << std::endl;
-
-    Vector2d angle_d_mean(3.14, -3.14);
-    Vector2d angle_d_weights(1, 1);
-
-    double d_mean = directional_mean(angle_d_mean, angle_d_weights);
-
-    std::cout << "Vector a:\n" << angle_d_mean << "\nVector w:\n" << angle_d_weights << "\nResult: " << d_mean << "\n" << std::endl;
-
-    if (!((d_mean -  3.14) < 0.01))
+    std::cout << "With 1 column:\n" << std::endl;
     {
-        std::cerr << "Directional mean produced wrong results, should be +/-3.14." << std::endl;
-        return EXIT_FAILURE;
+        MatrixXd angle_d_mean(2, 1);
+        angle_d_mean << 3.14,
+                        1.57;
+        VectorXd angle_d_weights(1);
+        angle_d_weights << 0.0;
+
+        Vector2d d_mean = directional_mean(angle_d_mean, angle_d_weights);
+
+        std::cout << "Matrix a:\n" << angle_d_mean << "\nVector w:\n" << angle_d_weights << "\nResult:\n" << d_mean << "\n" << std::endl;
+
+        if (!(((d_mean(0) -  3.14) < 0.01) && ((d_mean(1) -  1.57) < 0.01)))
+        {
+            std::cerr << "Directional mean produced wrong results." << std::endl;
+            return EXIT_FAILURE;
+        }
+        else
+            std::cout << "Directional mean produced correct results.\n" << std::endl;
     }
-    else
-        std::cout << "Directional mean produced correct results.\n" << std::endl;
 
+    std::cout << "With 2 columns:\n" << std::endl;
+    {
+        Matrix2d angle_d_mean;
+        angle_d_mean << 3.14, -3.14,
+                        1.57, -1.57;
+        Vector2d angle_d_weights(0.5, 0.5);
 
+        Vector2d d_mean = directional_mean(angle_d_mean, angle_d_weights);
+
+        std::cout << "Matrix a:\n" << angle_d_mean << "\nVector w:\n" << angle_d_weights << "\nResult:\n" << d_mean << "\n" << std::endl;
+
+        if (!(((d_mean(0) -  3.14) < 0.01) && ((d_mean(1) -  0.0) < 0.01)))
+        {
+            std::cerr << "Directional mean produced wrong results." << std::endl;
+            return EXIT_FAILURE;
+        }
+        else
+            std::cout << "Directional mean produced correct results.\n" << std::endl;
+    }
     std::cout << "...done!\n" << std::endl;
 
 


### PR DESCRIPTION
In this PR:
- Re-implement `directional_statistics::directional_add` using complex exponential in order to avoid wrapping angles by hand. With respect to the previous method, it also handles the case in which the sum of angles, to be wrapped, is of the form `alpha + 2 * k * pi` with `alpha` in `(-pi, pi]` and `k` an integer
- Re-implement `directional_statistics::directional_mean` in order to evaluate the weighted mean of **vectors** containing angles.
- Update `test_DirectionalStatistics`