### PR TITLE
Improve unscented transform utilities

### DIFF
--- a/src/BayesFilters/include/BayesFilters/sigma_point.h
+++ b/src/BayesFilters/include/BayesFilters/sigma_point.h
@@ -18,7 +18,14 @@ namespace bfl
 {
 namespace sigma_point
 {
-    using FunctionEvaluation = std::function<std::pair<bool, bfl::Data>(const Eigen::Ref<const Eigen::MatrixXd>&)>;
+    /**
+     * A FunctionEvaluation return
+     * - a boolean indicating if the evaluation was successful
+     * - the output data in the form of bfl::Data
+     * - the output size as a pair of std::size_t indicating linear and circular size
+     */
+    using OutputSize = std::pair<std::size_t, std::size_t>;
+    using FunctionEvaluation = std::function<std::tuple<bool, bfl::Data, OutputSize>(const Eigen::Ref<const Eigen::MatrixXd>&)>;
     
     struct UTWeight
     {

--- a/src/BayesFilters/include/BayesFilters/sigma_point.h
+++ b/src/BayesFilters/include/BayesFilters/sigma_point.h
@@ -5,7 +5,7 @@
 #include <BayesFilters/Data.h>
 #include <BayesFilters/ExogenousModel.h>
 #include <BayesFilters/GaussianMixture.h>
-#include <BayesFilters/LinearMeasurementModel.h>
+#include <BayesFilters/AdditiveMeasurementModel.h>
 #include <BayesFilters/MeasurementModel.h>
 #include <BayesFilters/StateModel.h>
 
@@ -57,7 +57,7 @@ namespace sigma_point
 
     std::tuple<bool, GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, MeasurementModel& meas_model);
 
-    std::tuple<bool, GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, LinearMeasurementModel& meas_model);
+    std::tuple<bool, GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, AdditiveMeasurementModel& meas_model);
 }
 }
 

--- a/src/BayesFilters/src/sigma_point.cpp
+++ b/src/BayesFilters/src/sigma_point.cpp
@@ -72,7 +72,10 @@ MatrixXd bfl::sigma_point::sigma_point(const GaussianMixture& state, const doubl
             sp.topRows(state.dim_linear).colwise() += state.mean(i).topRows(state.dim_linear);
 
         if (state.dim_circular > 0)
-            sp.bottomRows(state.dim_circular) = directional_add(sigma_points.bottomRows(state.dim_circular), state.mean(i).bottomRows(state.dim_circular));
+            sp.middleRows(state.dim_linear, state.dim_circular) = directional_add(sp.middleRows(state.dim_linear, state.dim_circular), state.mean(i).middleRows(state.dim_linear, state.dim_circular));
+
+        if (state.dim_noise > 0)
+            sp.bottomRows(state.dim_noise).colwise() += state.mean(i).bottomRows(state.dim_noise);
     }
 
     return sigma_points;

--- a/src/BayesFilters/src/sigma_point.cpp
+++ b/src/BayesFilters/src/sigma_point.cpp
@@ -309,7 +309,7 @@ std::tuple<bool, GaussianMixture, MatrixXd> bfl::sigma_point::unscented_transfor
 (
     const GaussianMixture& state,
     const UTWeight& weight,
-    LinearMeasurementModel& meas_model
+    AdditiveMeasurementModel& meas_model
 )
 {
     FunctionEvaluation f = [&meas_model](const Ref<const MatrixXd>& state)


### PR DESCRIPTION
In this PR:
- Changed implementation of `sigma_point::sigma_point` so that the size of the noise components, if any, is taken into account in the evaluation of the sigma points
- Extended the alias `sigma_point::FunctionEvaluation`. A function of this type now also returns a pair of `std::size_t` indicating the linear and circular size of the **output** of the function
- Changed implementation of core `sigma_point::unscented_transform` method and of adapters in order to use the new interface of `FunctionEvaluation`
- Changed implementation of core `sigma_point::unscented_transform` method in order to take into account circular components during addition, subtractions and mean evaluation
- Changed signature of method 
`sigma_points::unscented_transform(const GaussianMixture& state, const UTWeight& weight, LinearMeasurementModel& meas_model)` to 
`sigma_points::unscented_transform(const GaussianMixture& state, const UTWeight& weight, AdditiveMeasurementModel& meas_model)`, i.e. the support is extended to the broader class of additive measurement models

**Note:** at this point the core method `unscented_transform` can process Gaussians having noise components. When the cross-covariance between the input and the output is evaluated. the noise components are discarded and the cross-covariance between the input (all the input except the noise part) and the output is returned.