### PR TITLE
Improve logging facilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@
  - Constructor SIS::SIS takes the state size, linear and circular, as argument (required to initialize ParticleSet).
  - Method SIS::filteringStep uses VectorXi instead of VectorXf to represent particle parents.
  - Method SIS::filteringStep uses particle weights in log space instead of linear space.
+ - Moved default logging facilities of class SIS from method SIS::filteringStep to overriden method Logger::log.
  - Re-implemented class KalmanFilter, a general Gaussian filtering algorithm using a GaussianPrediction and a GaussianCorrection.
  - Renamed class KalmanFilter to GaussianFilter.
+ - Added call to virtual method Logger::log in method GaussianFilter::filteringStep.
 
 ##### `Filtering Functions`
  - Removed VisualParticleFilter class.

--- a/src/BayesFilters/include/BayesFilters/Logger.h
+++ b/src/BayesFilters/include/BayesFilters/Logger.h
@@ -55,6 +55,8 @@ public:
 protected:
     virtual std::vector<std::string> log_filenames(const std::string& prefix_path, const std::string& prefix_name);
 
+    virtual void log();
+
 private:
     std::string prefix_path_;
 

--- a/src/BayesFilters/include/BayesFilters/SIS.h
+++ b/src/BayesFilters/include/BayesFilters/SIS.h
@@ -52,6 +52,8 @@ protected:
                 prefix_path + "/" + prefix_name + "_cor_particles",
                 prefix_path + "/" + prefix_name + "_cor_weights"};
     }
+
+    void log() override;
 };
 
 #endif /* SIS_H */

--- a/src/BayesFilters/include/BayesFilters/SimulatedLinearSensor.h
+++ b/src/BayesFilters/include/BayesFilters/SimulatedLinearSensor.h
@@ -36,6 +36,8 @@ protected:
     std::size_t dim_linear_;
 
     std::size_t dim_circular_;
+
+    void log() override;
 };
 
 #endif /* SIMULATEDLINEARSENSOR_H */

--- a/src/BayesFilters/include/BayesFilters/SimulatedStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/SimulatedStateModel.h
@@ -50,6 +50,8 @@ protected:
     {
         return {prefix_path + "/" + prefix_name + "_target"};
     }
+
+    void log() override;
 };
 
 #endif /* SIMULATEDPROCESS_H */

--- a/src/BayesFilters/src/GaussianFilter.cpp
+++ b/src/BayesFilters/src/GaussianFilter.cpp
@@ -38,6 +38,8 @@ void GaussianFilter::filteringStep()
 {
     prediction_->predict(corrected_state_, predicted_state_);
     correction_->correct(predicted_state_, corrected_state_);
+
+    log();
 }
 
 

--- a/src/BayesFilters/src/Logger.cpp
+++ b/src/BayesFilters/src/Logger.cpp
@@ -94,3 +94,7 @@ std::vector<std::string> Logger::log_filenames(const std::string& prefix_path, c
 
     return {};
 }
+
+
+void Logger::log()
+{ }

--- a/src/BayesFilters/src/SIS.cpp
+++ b/src/BayesFilters/src/SIS.cpp
@@ -73,9 +73,7 @@ void SIS::filteringStep()
     /* Normalize weights using LogSumExp. */
     cor_particle_.weight().array() -= utils::log_sum_exp(cor_particle_.weight());
 
-    logger(pred_particle_.state().transpose(), pred_particle_.weight().transpose(),
-           cor_particle_.state().transpose(), cor_particle_.weight().transpose());
-
+    log();
 
     if (resampling_->neff(cor_particle_.weight()) < static_cast<double>(num_particle_)/3.0)
     {
@@ -92,4 +90,11 @@ void SIS::filteringStep()
 bool SIS::runCondition()
 {
     return true;
+}
+
+
+void SIS::log()
+{
+    logger(pred_particle_.state().transpose(), pred_particle_.weight().transpose(),
+           cor_particle_.state().transpose(), cor_particle_.weight().transpose());
 }

--- a/src/BayesFilters/src/SimulatedLinearSensor.cpp
+++ b/src/BayesFilters/src/SimulatedLinearSensor.cpp
@@ -68,7 +68,7 @@ bool SimulatedLinearSensor::freezeMeasurements()
 
     measurement_ += noise;
 
-    logger(measurement_.transpose());
+    log();
 
     return true;
 }
@@ -83,4 +83,10 @@ std::pair<bool, Data> SimulatedLinearSensor::measure() const
 std::pair<std::size_t, std::size_t> SimulatedLinearSensor::getOutputSize() const
 {
     return std::make_pair(dim_linear_, dim_circular_);
+}
+
+
+void SimulatedLinearSensor::log()
+{
+    logger(measurement_.transpose());
 }

--- a/src/BayesFilters/src/SimulatedStateModel.cpp
+++ b/src/BayesFilters/src/SimulatedStateModel.cpp
@@ -31,7 +31,7 @@ bool SimulatedStateModel::bufferData()
 {
     ++current_simulation_time_;
 
-    logger(target_.col(current_simulation_time_ - 1).transpose());
+    log();
 
     MatrixXd process_information = target_.col(current_simulation_time_ - 1);
 
@@ -64,4 +64,10 @@ bool SimulatedStateModel::setProperty(const std::string& property)
 StateModel& SimulatedStateModel::getStateModel()
 {
     return *state_model_;
+}
+
+
+void SimulatedStateModel::log()
+{
+    logger(target_.col(current_simulation_time_ - 1).transpose());
 }

--- a/test/test_KF/main.cpp
+++ b/test/test_KF/main.cpp
@@ -44,10 +44,8 @@ protected:
     }
 
 
-    void filteringStep() override
+    void log() override
     {
-        GaussianFilter::filteringStep();
-
         logger(predicted_state_.mean().transpose(), corrected_state_.mean().transpose());
     }
 

--- a/test/test_UKF/main.cpp
+++ b/test/test_UKF/main.cpp
@@ -45,10 +45,8 @@ protected:
     }
 
 
-    void filteringStep() override
+    void log() override
     {
-        GaussianFilter::filteringStep();
-
         logger(predicted_state_.mean().transpose(), corrected_state_.mean().transpose());
     }
 

--- a/test/test_UPF/main.cpp
+++ b/test/test_UPF/main.cpp
@@ -81,31 +81,13 @@ protected:
         return true;
     }
 
-    void filteringStep() override
+    void log() override
     {
-        if (getFilteringStep() != 0)
-            prediction_->predict(cor_particle_, pred_particle_);
-
-        correction_->correct(pred_particle_, cor_particle_);
-
-        /* Normalize weights using LogSumExp. */
-        cor_particle_.weight().array() -= utils::log_sum_exp(cor_particle_.weight());
-
         VectorXd mean = mean_extraction(cor_particle_);
 
         logger(pred_particle_.state().transpose(), pred_particle_.weight().transpose(),
                cor_particle_.state().transpose(), cor_particle_.weight().transpose(),
                mean.transpose());
-
-        if (resampling_->neff(cor_particle_.weight()) < static_cast<double>(num_particle_)/3.0)
-        {
-            ParticleSet res_particle(num_particle_, state_size_);
-            VectorXi res_parent(num_particle_, 1);
-
-            resampling_->resample(cor_particle_, res_particle, res_parent);
-
-            cor_particle_ = res_particle;
-        }
     }
 
 private:

--- a/test/test_mixed_KF_SUKF/main.cpp
+++ b/test/test_mixed_KF_SUKF/main.cpp
@@ -45,10 +45,8 @@ protected:
     }
 
 
-    void filteringStep() override
+    void log() override
     {
-        GaussianFilter::filteringStep();
-
         logger(predicted_state_.mean().transpose(), corrected_state_.mean().transpose());
     }
 

--- a/test/test_mixed_KF_UKF/main.cpp
+++ b/test/test_mixed_KF_UKF/main.cpp
@@ -45,10 +45,8 @@ protected:
     }
 
 
-    void filteringStep() override
+    void log() override
     {
-        GaussianFilter::filteringStep();
-
         logger(predicted_state_.mean().transpose(), corrected_state_.mean().transpose());
     }
 

--- a/test/test_mixed_UKF_KF/main.cpp
+++ b/test/test_mixed_UKF_KF/main.cpp
@@ -45,10 +45,8 @@ protected:
     }
 
 
-    void filteringStep() override
+    void log() override
     {
-        GaussianFilter::filteringStep();
-
         logger(predicted_state_.mean().transpose(), corrected_state_.mean().transpose());
     }
 


### PR DESCRIPTION
In this PR:
- Added virtual method `Logger::log`
- Added call to `Logger::log` within `GaussianFilter::filteringStep`
- Clean code in `test_KF`, `test_UKF`, `test_KF_UKF`, `test_UKF_KF`, `test_KF_SUKF` so that method `Logger::log` is overridden instead of `GaussianFilter::filteringStep` in order to log predicted and corrected mean
- Moved default logging facilities, i.e. logging predited/corrected particles/weights, from `SIS::filteringStep` to overridden method `Logger::log`
- Clean code in `test_UPF` so that method `Logger::log` is overridden instead of `SIS::filteringStep` in order to log the expected value of the estimate
- Moved default logging facilities, i.e. logging simulated measurement, from `SimulatedLinearSensor::freezeMeasurements` to overridden method `Logger::log`
- Moved default logging facilities, i.e. logging the simulated state, from `SimulatedStateModel::bufferData` to overridden method `Logger::log`

#### Changelog
- Updated `CHANGELOG.md`