### PR TITLE
Fix compile warnings and simplify tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # 📜 BayesFilters changelog
 
 ## 🔖 Version 0.8.101
+##### `Bugfix`
+ - Add initial value to bool variable in UKFCorrection::correctStep.
+
+##### `General fixes`
+ - Added missing `override` keyword.
+ - Reordered data member initialization list of SIS class.
 
 
 ## 🔖 Version 0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ##### `Bugfix`
  - Add initial value to bool variable in UKFCorrection::correctStep.
 
+##### `CMake`
+ - Add CMake variable TEST_LOG_TO_FILE to disable file logs in tests.
+
 ##### `General fixes`
  - Added missing `override` keyword.
  - Reordered data member initialization list of SIS class.

--- a/src/BayesFilters/include/BayesFilters/KFCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/KFCorrection.h
@@ -26,7 +26,7 @@ public:
 protected:
     void correctStep(const GaussianMixture& pred_state, GaussianMixture& corr_state) override;
 
-    std::pair<bool, Eigen::VectorXd> likelihood(const Eigen::Ref<const Eigen::MatrixXd>& innovations);
+    std::pair<bool, Eigen::VectorXd> likelihood(const Eigen::Ref<const Eigen::MatrixXd>& innovations) override;
 
 private:
     std::unique_ptr<LinearMeasurementModel> measurement_model_;

--- a/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
+++ b/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
@@ -36,7 +36,7 @@ public:
 
     Eigen::MatrixXd getStateTransitionMatrix() override;
 
-    Eigen::VectorXd getTransitionProbability(const Eigen::Ref<const Eigen::MatrixXd>& prev_states, Eigen::Ref<Eigen::MatrixXd> cur_states);
+    Eigen::VectorXd getTransitionProbability(const Eigen::Ref<const Eigen::MatrixXd>& prev_states, Eigen::Ref<Eigen::MatrixXd> cur_states) override;
 
     bool setProperty(const std::string& property) override { return false; };
 

--- a/src/BayesFilters/src/GaussianFilter.cpp
+++ b/src/BayesFilters/src/GaussianFilter.cpp
@@ -9,18 +9,18 @@ GaussianFilter::GaussianFilter
     std::unique_ptr<GaussianPrediction> prediction,
     std::unique_ptr<GaussianCorrection> correction
 ) noexcept :
-    prediction_(std::move(prediction)),
-    correction_(std::move(correction)),
     predicted_state_(initial_state.dim_linear, initial_state.dim_circular),
-    corrected_state_(initial_state)
+    corrected_state_(initial_state),
+    prediction_(std::move(prediction)),
+    correction_(std::move(correction))
 { }
 
 
 GaussianFilter::GaussianFilter(GaussianFilter&& gf) noexcept :
-    prediction_(std::move(gf.prediction_)),
-    correction_(std::move(gf.correction_)),
     predicted_state_(std::move(gf.predicted_state_)),
-    corrected_state_(std::move(gf.corrected_state_))
+    corrected_state_(std::move(gf.corrected_state_)),
+    prediction_(std::move(gf.prediction_)),
+    correction_(std::move(gf.correction_))
 { }
 
 

--- a/src/BayesFilters/src/SIS.cpp
+++ b/src/BayesFilters/src/SIS.cpp
@@ -48,10 +48,10 @@ SIS::~SIS() noexcept
 
 SIS::SIS(SIS&& sir_pf) noexcept :
     ParticleFilter(std::move(sir_pf)),
-    pred_particle_(std::move(sir_pf.pred_particle_)),
-    cor_particle_(std::move(sir_pf.cor_particle_)),
     num_particle_(sir_pf.num_particle_),
-    state_size_(sir_pf.state_size_)
+    state_size_(sir_pf.state_size_),
+    pred_particle_(std::move(sir_pf.pred_particle_)),
+    cor_particle_(std::move(sir_pf.cor_particle_))
 { }
 
 

--- a/src/BayesFilters/src/UKFCorrection.cpp
+++ b/src/BayesFilters/src/UKFCorrection.cpp
@@ -76,7 +76,7 @@ void UKFCorrection::correctStep(const GaussianMixture& pred_state, GaussianMixtu
     GaussianMixture pred_meas(pred_state.components, meas_size);
 
     /* Evaluate the joint state-measurement statistics, if possible. */
-    bool valid;
+    bool valid = false;
     MatrixXd Pxy;
     if (type_ == UKFCorrectionType::Generic)
     {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,5 @@
+option(TEST_LOG_TO_FILE "Write test logs to file" OFF)
+
 add_subdirectory(test_DirectionalStatisticsUtils)
 add_subdirectory(test_Gaussian)
 add_subdirectory(test_SigmaPointUtils)

--- a/test/test_KF/CMakeLists.txt
+++ b/test/test_KF/CMakeLists.txt
@@ -9,5 +9,5 @@ add_executable(${TEST_TARGET_NAME} ${${TEST_TARGET_NAME}_SRC})
 target_link_libraries(${TEST_TARGET_NAME} BayesFilters)
 
 add_test(NAME ${TEST_TARGET_NAME}
-         COMMAND ${TEST_TARGET_NAME}
+         COMMAND ${TEST_TARGET_NAME} ${TEST_LOG_TO_FILE}
          WORKING_DIRECTORY $<TARGET_FILE_DIR:${TEST_TARGET_NAME}>)

--- a/test/test_SIS/CMakeLists.txt
+++ b/test/test_SIS/CMakeLists.txt
@@ -9,5 +9,5 @@ add_executable(${TEST_TARGET_NAME} ${${TEST_TARGET_NAME}_SRC})
 target_link_libraries(${TEST_TARGET_NAME} BayesFilters)
 
 add_test(NAME ${TEST_TARGET_NAME}
-         COMMAND ${TEST_TARGET_NAME}
+         COMMAND ${TEST_TARGET_NAME} ${TEST_LOG_TO_FILE}
          WORKING_DIRECTORY $<TARGET_FILE_DIR:${TEST_TARGET_NAME}>)

--- a/test/test_SIS/main.cpp
+++ b/test/test_SIS/main.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <memory>
+#include <string>
 
 #include <BayesFilters/BootstrapCorrection.h>
 #include <BayesFilters/DrawParticles.h>
@@ -48,16 +49,20 @@ private:
 };
 
 
-int main()
+int main(int argc, char* argv[])
 {
     std::cout << "Running a SIS particle filter on a simulated target." << std::endl;
-    std::cout << "Data is logged in the test folder with prefix testSIS." << std::endl;
 
+    const bool write_to_file = (argc > 1 ? std::string(argv[1]) == "ON" : false);
+    if (write_to_file)
+        std::cout << "Data is logged in the test folder with prefix testSIS." << std::endl;
+
+    
     /* A set of parameters needed to run a SIS particle filter in a simulated environment. */
     double surv_x = 1000.0;
     double surv_y = 1000.0;
-    unsigned int num_particle_x = 100;
-    unsigned int num_particle_y = 100;
+    unsigned int num_particle_x = 30;
+    unsigned int num_particle_y = 30;
     unsigned int num_particle = num_particle_x * num_particle_y;
     Vector4d initial_state(10.0f, 0.0f, 10.0f, 0.0f);
     unsigned int simulation_time = 100;
@@ -87,11 +92,15 @@ int main()
     /* Initialize simulaterd target model with a white noise acceleration. */
     std::unique_ptr<StateModel> target_model = utils::make_unique<WhiteNoiseAcceleration>(T, tilde_q);
     std::unique_ptr<SimulatedStateModel> simulated_state_model = utils::make_unique<SimulatedStateModel>(std::move(target_model), initial_state, simulation_time);
-    simulated_state_model->enable_log(".", "testSIS");
+
+    if (write_to_file)
+        simulated_state_model->enable_log(".", "testSIS");
 
     /* Initialize a measurement model (a linear sensor reading x and y coordinates). */
     std::unique_ptr<MeasurementModel> simulated_linear_sensor = utils::make_unique<SimulatedLinearSensor>(std::move(simulated_state_model));
-    simulated_linear_sensor->enable_log(".", "testSIS");
+
+    if (write_to_file)
+        simulated_linear_sensor->enable_log(".", "testSIS");
 
 
     /* Step 3.3 - Define the likelihood model */
@@ -113,7 +122,10 @@ int main()
     /* Step 5 - Assemble the particle filter */
     std::cout << "Constructing SIS particle filter..." << std::flush;
     SISSimulation sis_pf(num_particle, state_size, simulation_time, std::move(grid_initialization), std::move(pf_prediction), std::move(pf_correction), std::move(resampling));
-    sis_pf.enable_log(".", "testSIS");
+
+    if (write_to_file)
+        sis_pf.enable_log(".", "testSIS");
+    
     std::cout << "done!" << std::endl;
 
 

--- a/test/test_SIS_Decorators/main.cpp
+++ b/test/test_SIS_Decorators/main.cpp
@@ -126,11 +126,13 @@ private:
 
 int main()
 {
+    std::cout << "Running a Decorated SIS particle filter on a simulated target." << std::endl;
+    
     /* A set of parameters needed to run a SIS particle filter in a simulated environment. */
     double surv_x = 1000.0;
     double surv_y = 1000.0;
-    unsigned int num_particle_x = 100;
-    unsigned int num_particle_y = 100;
+    unsigned int num_particle_x = 30;
+    unsigned int num_particle_y = 30;
     unsigned int num_particle = num_particle_x * num_particle_y;
     Vector4d initial_state(10.0f, 0.0f, 10.0f, 0.0f);
     unsigned int simulation_time = 10;

--- a/test/test_UKF/CMakeLists.txt
+++ b/test/test_UKF/CMakeLists.txt
@@ -9,5 +9,5 @@ add_executable(${TEST_TARGET_NAME} ${${TEST_TARGET_NAME}_SRC})
 target_link_libraries(${TEST_TARGET_NAME} BayesFilters)
 
 add_test(NAME ${TEST_TARGET_NAME}
-         COMMAND ${TEST_TARGET_NAME}
+         COMMAND ${TEST_TARGET_NAME} ${TEST_LOG_TO_FILE}
          WORKING_DIRECTORY $<TARGET_FILE_DIR:${TEST_TARGET_NAME}>)

--- a/test/test_UPF/CMakeLists.txt
+++ b/test/test_UPF/CMakeLists.txt
@@ -9,5 +9,5 @@ add_executable(${TEST_TARGET_NAME} ${${TEST_TARGET_NAME}_SRC})
 target_link_libraries(${TEST_TARGET_NAME} BayesFilters)
 
 add_test(NAME ${TEST_TARGET_NAME}
-         COMMAND ${TEST_TARGET_NAME}
+         COMMAND ${TEST_TARGET_NAME} ${TEST_LOG_TO_FILE}
          WORKING_DIRECTORY $<TARGET_FILE_DIR:${TEST_TARGET_NAME}>)

--- a/test/test_mixed_KF_SUKF/CMakeLists.txt
+++ b/test/test_mixed_KF_SUKF/CMakeLists.txt
@@ -9,5 +9,5 @@ add_executable(${TEST_TARGET_NAME} ${${TEST_TARGET_NAME}_SRC})
 target_link_libraries(${TEST_TARGET_NAME} BayesFilters)
 
 add_test(NAME ${TEST_TARGET_NAME}
-         COMMAND ${TEST_TARGET_NAME}
+         COMMAND ${TEST_TARGET_NAME} ${TEST_LOG_TO_FILE}
          WORKING_DIRECTORY $<TARGET_FILE_DIR:${TEST_TARGET_NAME}>)

--- a/test/test_mixed_KF_UKF/CMakeLists.txt
+++ b/test/test_mixed_KF_UKF/CMakeLists.txt
@@ -9,5 +9,5 @@ add_executable(${TEST_TARGET_NAME} ${${TEST_TARGET_NAME}_SRC})
 target_link_libraries(${TEST_TARGET_NAME} BayesFilters)
 
 add_test(NAME ${TEST_TARGET_NAME}
-         COMMAND ${TEST_TARGET_NAME}
+         COMMAND ${TEST_TARGET_NAME} ${TEST_LOG_TO_FILE}
          WORKING_DIRECTORY $<TARGET_FILE_DIR:${TEST_TARGET_NAME}>)

--- a/test/test_mixed_UKF_KF/CMakeLists.txt
+++ b/test/test_mixed_UKF_KF/CMakeLists.txt
@@ -9,5 +9,5 @@ add_executable(${TEST_TARGET_NAME} ${${TEST_TARGET_NAME}_SRC})
 target_link_libraries(${TEST_TARGET_NAME} BayesFilters)
 
 add_test(NAME ${TEST_TARGET_NAME}
-         COMMAND ${TEST_TARGET_NAME}
+         COMMAND ${TEST_TARGET_NAME} ${TEST_LOG_TO_FILE}
          WORKING_DIRECTORY $<TARGET_FILE_DIR:${TEST_TARGET_NAME}>)


### PR DESCRIPTION
This PR fixes some compile warnings, like missing overrides and uninitialized boolean values, and significantly reduces test time. To accomplish the latter, a `TEST_LOG_TO_FILE` variable can be set to `ON` or `OFF` (default is `OFF`) during CMake configuration to allow saving filter logs to file.
This is particularly useful for running tests locally, where one would probably want to enable logs to files, or remotely, where one instead wants tests to run fast and is unable to collect logs.
This PR also reduces the number of points used by the particle filters from `10000` to `900`.

Closes #18.