### PR TITLE
Fix wrong name of class 'BootstrapCorrection'

### DIFF
--- a/src/BayesFilters/include/BayesFilters/BootstrapCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/BootstrapCorrection.h
@@ -1,5 +1,5 @@
-#ifndef UPDATEPARTICLES_H
-#define UPDATEPARTICLES_H
+#ifndef BOOTSTRAPCORRECTION_H
+#define BOOTSTRAPCORRECTION_H
 
 #include <BayesFilters/ParticleSet.h>
 #include <BayesFilters/PFCorrection.h>
@@ -40,4 +40,4 @@ protected:
     Eigen::VectorXd likelihood_;
 };
 
-#endif /* UPDATEPARTICLES_H */
+#endif /* BOOTSTRAPCORRECTION_H */

--- a/src/BayesFilters/include/BayesFilters/BootstrapCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/BootstrapCorrection.h
@@ -8,16 +8,16 @@
 #include <random>
 
 namespace bfl {
-    class BoostrapCorrection;
+    class BootstrapCorrection;
 }
 
 
-class bfl::BoostrapCorrection : public PFCorrection
+class bfl::BootstrapCorrection : public PFCorrection
 {
 public:
-    BoostrapCorrection() noexcept;
+    BootstrapCorrection() noexcept;
 
-    virtual ~BoostrapCorrection() noexcept;
+    virtual ~BootstrapCorrection() noexcept;
 
     void setLikelihoodModel(std::unique_ptr<LikelihoodModel> likelihood_model) override;
 

--- a/src/BayesFilters/src/BootstrapCorrection.cpp
+++ b/src/BayesFilters/src/BootstrapCorrection.cpp
@@ -7,13 +7,13 @@ using namespace bfl;
 using namespace Eigen;
 
 
-BoostrapCorrection::BoostrapCorrection() noexcept { }
+BootstrapCorrection::BootstrapCorrection() noexcept { }
 
 
-BoostrapCorrection::~BoostrapCorrection() noexcept { }
+BootstrapCorrection::~BootstrapCorrection() noexcept { }
 
 
-void BoostrapCorrection::correctStep(const ParticleSet& pred_particles, ParticleSet& cor_particles)
+void BootstrapCorrection::correctStep(const ParticleSet& pred_particles, ParticleSet& cor_particles)
 {
     std::tie(valid_likelihood_, likelihood_) = likelihood_model_->likelihood(*measurement_model_, pred_particles.state());
 
@@ -24,31 +24,31 @@ void BoostrapCorrection::correctStep(const ParticleSet& pred_particles, Particle
 }
 
 
-std::pair<bool, VectorXd> BoostrapCorrection::getLikelihood()
+std::pair<bool, VectorXd> BootstrapCorrection::getLikelihood()
 {
     return std::make_pair(valid_likelihood_, likelihood_);
 }
 
 
-void BoostrapCorrection::setLikelihoodModel(std::unique_ptr<LikelihoodModel> likelihood_model)
+void BootstrapCorrection::setLikelihoodModel(std::unique_ptr<LikelihoodModel> likelihood_model)
 {
     likelihood_model_ = std::move(likelihood_model);
 }
 
 
-void BoostrapCorrection::setMeasurementModel(std::unique_ptr<MeasurementModel> measurement_model)
+void BootstrapCorrection::setMeasurementModel(std::unique_ptr<MeasurementModel> measurement_model)
 {
     measurement_model_ = std::move(measurement_model);
 }
 
 
-LikelihoodModel& BoostrapCorrection::getLikelihoodModel()
+LikelihoodModel& BootstrapCorrection::getLikelihoodModel()
 {
     return *likelihood_model_;
 }
 
 
-MeasurementModel& BoostrapCorrection::getMeasurementModel()
+MeasurementModel& BootstrapCorrection::getMeasurementModel()
 {
     return *measurement_model_;
 }

--- a/test/test_SIS/main.cpp
+++ b/test/test_SIS/main.cpp
@@ -109,7 +109,7 @@ int main(int argc, char* argv[])
 
     /* Step 3.4 - Define the correction step */
     /* Initialize the particle filter correction step and pass the ownership of the measurement model. */
-    std::unique_ptr<PFCorrection> pf_correction = utils::make_unique<BoostrapCorrection>();
+    std::unique_ptr<PFCorrection> pf_correction = utils::make_unique<BootstrapCorrection>();
     pf_correction->setLikelihoodModel(std::move(exp_likelihood));
     pf_correction->setMeasurementModel(std::move(simulated_linear_sensor));
 

--- a/test/test_SIS_Decorators/main.cpp
+++ b/test/test_SIS_Decorators/main.cpp
@@ -181,7 +181,7 @@ int main()
 
     /* Step 3.3 - Define the correction step */
     /* Initialize the particle filter correction step and pass the ownership of the measurement model. */
-    std::unique_ptr<PFCorrection> pf_correction = utils::make_unique<BoostrapCorrection>();
+    std::unique_ptr<PFCorrection> pf_correction = utils::make_unique<BootstrapCorrection>();
     pf_correction->setLikelihoodModel(std::move(exp_likelihood));
     pf_correction->setMeasurementModel(std::move(decorated_linearsensor));
 


### PR DESCRIPTION
This PR fixes the name of the class `BoostrapCorrection` that should be instead `BootstrapCorrection`.

Tests `test_SIS` and `test_SIS_Decorators` are updated accordingly.