### PR TITLE
Fix missing input argument in MeasurementModelDecorator::measure()

### DIFF
--- a/src/BayesFilters/include/BayesFilters/MeasurementModelDecorator.h
+++ b/src/BayesFilters/include/BayesFilters/MeasurementModelDecorator.h
@@ -20,7 +20,7 @@ namespace bfl {
 class bfl::MeasurementModelDecorator : public MeasurementModel
 {
 public:
-    std::pair<bool, bfl::Data> measure() const override;
+    std::pair<bool, bfl::Data> measure(const Data& data = Data()) const override;
 
     std::pair<bool, bfl::Data> predictedMeasure(const Eigen::Ref<const Eigen::MatrixXd>& cur_states) const override;
 

--- a/src/BayesFilters/src/MeasurementModelDecorator.cpp
+++ b/src/BayesFilters/src/MeasurementModelDecorator.cpp
@@ -30,7 +30,7 @@ MeasurementModelDecorator& MeasurementModelDecorator::operator=(MeasurementModel
 }
 
 
-std::pair<bool, Data> MeasurementModelDecorator::measure() const
+std::pair<bool, Data> MeasurementModelDecorator::measure(const Data& data) const
 {
     return measurement_model->measure();
 }


### PR DESCRIPTION
This PR fixes a missing input argument in method `MeasurementModelDecorator::measure()`.