### PR TITLE
Implement utility for evaluating multivariate Gaussian density

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Implemented method GaussianMixture::resize().
 - Implemented method Gaussian::resize().
 - Implemented method ParticleSet::resize().
+- Implemented evaluation of a multivariate Gaussian probability density function in method utils::multivariate_gaussian_density.
+- Implemented evaluation of the logarithm of a multivariate Gaussian probability density function in method utils::multivariate_gaussian_log_density.
 - Methods EstimatesExtraction::extract() return a std::pair containing a boolean indicating if the estimate is valid and the estracted estimate.
 - Methods EstimatesExtraction::extract() assume that particle weights are in the log space.
 - Constructor HistoryBuffer::HistoryBuffer() takes the state size.
@@ -23,9 +25,14 @@
 ##### `Filtering functions`
 - Added pure public virtual method GaussianPrediction::getStateModel() (required to properly implement GPFPrediction::getStateModel()).
 - Implemented method KFPrediction::getStateModel().
+- Implemented method KFCorrection::getLikelihood().
 - Implemented method UKFPrediction::getStateModel().
+- Implemented method UKFCorrection::getLikelihood().
+- Changed implementation of GaussianLikelihood::likelihood().
 - Changed implementation of GPFPrediction::getStateModel().
 - Changed implementation of GPFCorrection::getLikelihood().
+- Changed implementation of GPFCorrection::evaluateProposal().
+- Changed implementation of WhiteNoiseAcceleration::getTransitionProbability().
 - Fixed missing const(s) keywords in signature of method StateModel::getTransitionProbability().
 - Fixed missing const(s) keywords in signature of method WhiteNoiseAcceleration::getTransitionProbability().
 - SUKFCorrection::getNoiseCovarianceMatrix() is now virtual.

--- a/src/BayesFilters/include/BayesFilters/KFCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/KFCorrection.h
@@ -30,11 +30,16 @@ public:
 
     MeasurementModel& getMeasurementModel() override;
 
+    std::pair<bool, Eigen::VectorXd> getLikelihood() override;
+
 protected:
     void correctStep(const GaussianMixture& pred_state, GaussianMixture& corr_state) override;
 
-private:
     std::unique_ptr<LinearMeasurementModel> measurement_model_;
+
+    Eigen::MatrixXd innovations_;
+
+    GaussianMixture meas_covariances_;
 };
 
 #endif /* KFCORRECTION_H */

--- a/src/BayesFilters/include/BayesFilters/UKFCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/UKFCorrection.h
@@ -34,6 +34,8 @@ public:
 
     MeasurementModel& getMeasurementModel() override;
 
+    std::pair<bool, Eigen::VectorXd> getLikelihood() override;
+
 protected:
     void correctStep(const GaussianMixture& pred_state, GaussianMixture& corr_state) override;
 
@@ -53,6 +55,10 @@ protected:
      * Unscented transform weight.
      */
     sigma_point::UTWeight ut_weight_;
+
+    Eigen::MatrixXd innovations_;
+
+    GaussianMixture predicted_meas_;
 };
 
 #endif /* UKFCORRECTION_H */

--- a/src/BayesFilters/include/BayesFilters/utils.h
+++ b/src/BayesFilters/include/BayesFilters/utils.h
@@ -84,6 +84,22 @@ Eigen::VectorXd multivariate_gaussian_log_density(const Eigen::MatrixBase<Derive
 
 
 /**
+ * Evaluate a multivariate Gaussian probability density function.
+ *
+ * @param input Input representing the argument of the function as a vector or matrix.
+ * @param mean The mean of the associated Gaussian distribution as a vector.
+ * @param covariance The covariance matrix of the associated Gaussian distribution as a matrix.
+ *
+ * @return The value of the density function evaluated on the input data as a vector.
+ */
+template<typename Derived>
+Eigen::VectorXd multivariate_gaussian_density(const Eigen::MatrixBase<Derived>& input, const Eigen::Ref<const Eigen::VectorXd>& mean, const Eigen::Ref<const Eigen::MatrixXd>& covariance)
+{
+    return multivariate_gaussian_log_density(input, mean, covariance).array().exp();
+}
+
+
+/**
  * This template class provides methods to keep track of time. The default time unit is milliseconds,
  * but can be changed during object creation using a different std::chrono::duration type.
  * See https://en.cppreference.com/w/cpp/chrono/duration for reference.

--- a/src/BayesFilters/include/BayesFilters/utils.h
+++ b/src/BayesFilters/include/BayesFilters/utils.h
@@ -62,6 +62,28 @@ double log_sum_exp(const Eigen::Ref<const Eigen::VectorXd>& arguments);
 
 
 /**
+ * Evaluate the logarithm of a multivariate Gaussian probability density function.
+ *
+ * @param input Input representing the argument of the function as a vector or matrix.
+ * @param mean The mean of the associated Gaussian distribution as a vector.
+ * @param covariance The covariance matrix of the associated Gaussian distribution as a matrix.
+ *
+ * @return The value of the logarithm of the density function evaluated on the input data as a vector.
+ */
+template<typename Derived>
+Eigen::VectorXd multivariate_gaussian_log_density(const Eigen::MatrixBase<Derived>& input, const Eigen::Ref<const Eigen::VectorXd>& mean, const Eigen::Ref<const Eigen::MatrixXd>& covariance)
+{
+    const auto diff = input.colwise() - mean;
+
+    Eigen::VectorXd values(diff.cols());
+    for (std::size_t i = 0; i < diff.cols(); i++)
+        values(i) = - 0.5 * (static_cast<double>(diff.rows()) * std::log(2.0 * M_PI) + std::log(covariance.determinant()) + (diff.col(i).transpose() * covariance.inverse() * diff.col(i)));
+
+    return values;
+}
+
+
+/**
  * This template class provides methods to keep track of time. The default time unit is milliseconds,
  * but can be changed during object creation using a different std::chrono::duration type.
  * See https://en.cppreference.com/w/cpp/chrono/duration for reference.

--- a/src/BayesFilters/src/GPFCorrection.cpp
+++ b/src/BayesFilters/src/GPFCorrection.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <BayesFilters/GPFCorrection.h>
+#include <BayesFilters/utils.h>
 
 #include <Eigen/Cholesky>
 
@@ -144,7 +145,5 @@ double GPFCorrection::evaluateProposal
 {
     /* Evaluate the proposal distribution, a Gaussian centered in 'mean' and having
        covariance 'covariance', in the state 'state'. */
-    VectorXd difference = state - mean;
-
-    return (-0.5 * static_cast<double>(difference.size()) * log(2.0 * M_PI) -0.5 * log(covariance.determinant()) -0.5 * (difference.transpose() * covariance.inverse() * difference).array()).exp().coeff(0);
+    return utils::multivariate_gaussian_density(state, mean, covariance).coeff(0);
 }

--- a/src/BayesFilters/src/GaussianLikelihood.cpp
+++ b/src/BayesFilters/src/GaussianLikelihood.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <BayesFilters/GaussianLikelihood.h>
+#include <BayesFilters/utils.h>
 
 using namespace bfl;
 using namespace Eigen;
@@ -68,9 +69,7 @@ std::pair<bool, VectorXd> GaussianLikelihood::likelihood
     if (!valid_covariance_matrix)
         return std::make_pair(false, VectorXd::Zero(1));
 
-
-    for (unsigned int i = 0; i < innovations.cols(); ++i)
-        likelihood(i) = scale_factor_ * (-0.5 * static_cast<double>(innovations.rows()) * log(2.0*M_PI) - 0.5 * log(covariance_matrix.determinant()) - 0.5 * (innovations.col(i).transpose() * covariance_matrix.inverse() * innovations.col(i)).array()).exp().coeff(0);
+    likelihood = scale_factor_ * utils::multivariate_gaussian_density(innovations, VectorXd::Zero(innovations.rows()), covariance_matrix);
 
     return std::make_pair(true, likelihood);
 }

--- a/src/BayesFilters/src/WhiteNoiseAcceleration.cpp
+++ b/src/BayesFilters/src/WhiteNoiseAcceleration.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <BayesFilters/WhiteNoiseAcceleration.h>
+#include <BayesFilters/utils.h>
 
 #include <cmath>
 #include <utility>
@@ -139,16 +140,7 @@ MatrixXd WhiteNoiseAcceleration::getStateTransitionMatrix()
 
 VectorXd WhiteNoiseAcceleration::getTransitionProbability(const Ref<const MatrixXd>& prev_states, const Ref<const MatrixXd>& cur_states)
 {
-    VectorXd probabilities(prev_states.cols());
-    MatrixXd differences = cur_states - prev_states;
-
-    std::size_t size = differences.rows();
-    for (std::size_t i = 0; i < prev_states.cols(); i++)
-    {
-        probabilities(i) = (-0.5 * static_cast<double>(size) * log(2.0 * M_PI) + -0.5 * log(Q_.determinant()) -0.5 * (differences.col(i).transpose() * Q_.inverse() * differences.col(i)).array()).exp().coeff(0);
-    }
-
-    return probabilities;
+    return utils::multivariate_gaussian_density(prev_states, prev_states.col(0), Q_);
 }
 
 


### PR DESCRIPTION
Within this PR:
- implemented a utility function, `utils::multivariate_gaussian_density`, for evaluation of a multivariate Gaussian probability density function;
- changed implementation of methods `GaussianLikelihood::likelihood`, `WhiteNoiseAcceleration::getTransitionProbability`, `GPFCorrection::evaluateProposal` so that `utils::multivariate_gaussian_density` is used
- implemented methods `{KF, UKF}Correction::getLikelihood`
- updated `CHANGELOG.md`

This closes #59 , closes #42 