### PR TITLE
Implement resize method for GaussianMixture and related classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Class EstimatesExtraction does not assume that the state is a 7-vector containing cartesian position and axis/angle representation of orientation anymore.
 - Implemented MAP (maximum a posteriori) estimate extraction within method EstimatesExtraction::map().
 - Implemented overloaded version of EstimatesExtraction::extract() taking extra arguments (particle weights at the previous time step, likelihoods at the current step and matrix of Markov transition probabilities between previous and current states) required to expose MAP extraction utiliy to the user.
+- Implemented method GaussianMixture::resize().
+- Implemented method Gaussian::resize().
+- Implemented method ParticleSet::resize().
 - Methods EstimatesExtraction::extract() return a std::pair containing a boolean indicating if the estimate is valid and the estracted estimate.
 - Methods EstimatesExtraction::extract() assume that particle weights are in the log space.
 - Constructor HistoryBuffer::HistoryBuffer() takes the state size.
@@ -32,7 +35,7 @@
 - Add mean extraction and logging in test_SIS to simplify inspection of the algorithm outcome.
 - Reduce number of particles in test_SIS to reduce testing computation time in Debug.
 - Add testUPF_MAP testing MAP (maximum a posteriori) estimate extraction within a UPF particle filter.
-
+- Change test_Gaussian in order to test resizing.
 
 ## 🔖 Version 0.8.101
 ##### `Bugfix`

--- a/src/BayesFilters/include/BayesFilters/Gaussian.h
+++ b/src/BayesFilters/include/BayesFilters/Gaussian.h
@@ -30,6 +30,8 @@ public:
 
     virtual ~Gaussian() noexcept;
 
+    void resize(const std::size_t dim_linear, const std::size_t dim_circular = 0);
+
     /**
      * Non-virtual methods of GaussianMixture are overriden here
      * since a Gaussian is a 1-component GaussianMixture.

--- a/src/BayesFilters/include/BayesFilters/Gaussian.h
+++ b/src/BayesFilters/include/BayesFilters/Gaussian.h
@@ -22,11 +22,13 @@ namespace bfl {
 class bfl::Gaussian : public bfl::GaussianMixture
 {
 public:
-    Gaussian();
+    Gaussian() noexcept;
 
-    Gaussian(const std::size_t dim_linear);
+    Gaussian(const std::size_t dim_linear) noexcept;
 
-    Gaussian(const std::size_t dim_linear, const std::size_t dim_circular);
+    Gaussian(const std::size_t dim_linear, const std::size_t dim_circular) noexcept;
+
+    virtual ~Gaussian() noexcept;
 
     /**
      * Non-virtual methods of GaussianMixture are overriden here
@@ -54,8 +56,6 @@ public:
     double& weight();
 
     const double& weight() const;
-
-    virtual ~Gaussian() noexcept { };
 };
 
 #endif /* GAUSSIAN_H */

--- a/src/BayesFilters/include/BayesFilters/GaussianMixture.h
+++ b/src/BayesFilters/include/BayesFilters/GaussianMixture.h
@@ -20,11 +20,11 @@ namespace bfl {
 class bfl::GaussianMixture
 {
 public:
-    GaussianMixture();
+    GaussianMixture() noexcept;
 
-    GaussianMixture(const std::size_t components, const std::size_t dim);
+    GaussianMixture(const std::size_t components, const std::size_t dim) noexcept;
 
-    GaussianMixture(const std::size_t components, const std::size_t dim_linear, const std::size_t dim_circular);
+    GaussianMixture(const std::size_t components, const std::size_t dim_linear, const std::size_t dim_circular) noexcept;
 
     virtual ~GaussianMixture() noexcept;
 

--- a/src/BayesFilters/include/BayesFilters/GaussianMixture.h
+++ b/src/BayesFilters/include/BayesFilters/GaussianMixture.h
@@ -28,6 +28,8 @@ public:
 
     virtual ~GaussianMixture() noexcept;
 
+    virtual void resize(const std::size_t components, const std::size_t dim_linear, const std::size_t dim_circular = 0);
+
     Eigen::Ref<Eigen::MatrixXd> mean();
 
     Eigen::Ref<Eigen::VectorXd> mean(const std::size_t i);

--- a/src/BayesFilters/include/BayesFilters/ParticleSet.h
+++ b/src/BayesFilters/include/BayesFilters/ParticleSet.h
@@ -28,6 +28,8 @@ public:
 
     virtual ~ParticleSet() noexcept;
 
+    void resize(const std::size_t components, const std::size_t dim_linear, const std::size_t dim_circular = 0) override;
+
     ParticleSet& operator+=(const ParticleSet& rhs);
 
     Eigen::Ref<Eigen::MatrixXd> state();

--- a/src/BayesFilters/include/BayesFilters/ParticleSet.h
+++ b/src/BayesFilters/include/BayesFilters/ParticleSet.h
@@ -20,6 +20,8 @@ namespace bfl {
 class bfl::ParticleSet : public bfl::GaussianMixture
 {
 public:
+    ParticleSet() noexcept;
+
     ParticleSet(const std::size_t components, const std::size_t dim) noexcept;
 
     ParticleSet(const std::size_t components, const std::size_t dim_linear, const std::size_t dim_circular) noexcept;

--- a/src/BayesFilters/src/Gaussian.cpp
+++ b/src/BayesFilters/src/Gaussian.cpp
@@ -12,18 +12,22 @@
 using namespace bfl;
 using namespace Eigen;
 
-Gaussian::Gaussian() :
+Gaussian::Gaussian() noexcept :
     GaussianMixture(1, 1)
 { }
 
 
-Gaussian::Gaussian(const std::size_t dim_linear) :
+Gaussian::Gaussian(const std::size_t dim_linear) noexcept :
     GaussianMixture(1, dim_linear)
 { }
 
 
-Gaussian::Gaussian(const std::size_t dim_linear, const std::size_t dim_circular) :
+Gaussian::Gaussian(const std::size_t dim_linear, const std::size_t dim_circular) noexcept :
     GaussianMixture(1, dim_linear, dim_circular)
+{ }
+
+
+Gaussian::~Gaussian() noexcept
 { }
 
 

--- a/src/BayesFilters/src/Gaussian.cpp
+++ b/src/BayesFilters/src/Gaussian.cpp
@@ -31,6 +31,12 @@ Gaussian::~Gaussian() noexcept
 { }
 
 
+void Gaussian::resize(const std::size_t dim_linear, const std::size_t dim_circular)
+{
+    GaussianMixture::resize(1, dim_linear, dim_circular);
+}
+
+
 Ref<VectorXd> Gaussian::mean()
 {
     return mean_.col(0);

--- a/src/BayesFilters/src/GaussianMixture.cpp
+++ b/src/BayesFilters/src/GaussianMixture.cpp
@@ -11,12 +11,12 @@ using namespace bfl;
 using namespace Eigen;
 
 
-GaussianMixture::GaussianMixture() :
+GaussianMixture::GaussianMixture() noexcept:
     GaussianMixture(1, 1, 0)
 { }
 
 
-GaussianMixture::GaussianMixture(const std::size_t components, const std::size_t dim) :
+GaussianMixture::GaussianMixture(const std::size_t components, const std::size_t dim) noexcept :
     GaussianMixture(components, dim, 0)
 { }
 
@@ -26,7 +26,7 @@ GaussianMixture::GaussianMixture
     const std::size_t components,
     const std::size_t dim_linear,
     const std::size_t dim_circular
-) :
+) noexcept :
     components(components),
     dim(dim_linear + dim_circular),
     dim_linear(dim_linear),
@@ -41,7 +41,8 @@ GaussianMixture::GaussianMixture
 }
 
 
-GaussianMixture::~GaussianMixture() noexcept { }
+GaussianMixture::~GaussianMixture() noexcept
+{ }
 
 
 Ref<MatrixXd> GaussianMixture::mean()

--- a/src/BayesFilters/src/GaussianMixture.cpp
+++ b/src/BayesFilters/src/GaussianMixture.cpp
@@ -45,6 +45,34 @@ GaussianMixture::~GaussianMixture() noexcept
 { }
 
 
+void GaussianMixture::resize(const std::size_t components, const std::size_t dim_linear, const std::size_t dim_circular)
+{
+    std::size_t new_dim = dim_linear + dim_circular;
+
+    if ((this->dim_linear == dim_linear) && (this->dim_circular == dim_circular) && (this->components == components))
+        return;
+    else if ((this->dim == new_dim) && (this->components != components))
+    {
+        mean_.conservativeResize(NoChange, components);
+        covariance_.conservativeResize(NoChange, dim * components);
+        weight_.conservativeResize(components);
+    }
+    else
+    {
+        // In any other case, it does not make sense to do conservative resize
+        // since either old data is truncated or new data is incomplete
+        mean_.resize(new_dim, components);
+        covariance_.resize(new_dim, new_dim * components);
+        weight_.resize(components);
+    }
+
+    this->components = components;
+    this->dim = new_dim;
+    this->dim_linear = dim_linear;
+    this->dim_circular = dim_circular;
+}
+
+
 Ref<MatrixXd> GaussianMixture::mean()
 {
     return mean_;

--- a/src/BayesFilters/src/ParticleSet.cpp
+++ b/src/BayesFilters/src/ParticleSet.cpp
@@ -10,9 +10,14 @@
 using namespace bfl;
 using namespace Eigen;
 
+ParticleSet::ParticleSet() noexcept :
+    ParticleSet(1, 1, 0)
+{ }
+
 
 ParticleSet::ParticleSet(const std::size_t components, const std::size_t dim) noexcept:
-    ParticleSet(components, dim, 0) { }
+    ParticleSet(components, dim, 0)
+{ }
 
 
 ParticleSet::ParticleSet
@@ -22,7 +27,12 @@ ParticleSet::ParticleSet
     const std::size_t dim_circular
 ) noexcept :
     GaussianMixture(components, dim_linear, dim_circular),
-    state_(dim, components) { }
+    state_(dim, components)
+{ }
+
+
+ParticleSet::~ParticleSet() noexcept
+{ }
 
 
 ParticleSet::~ParticleSet() noexcept { }

--- a/src/BayesFilters/src/ParticleSet.cpp
+++ b/src/BayesFilters/src/ParticleSet.cpp
@@ -35,7 +35,23 @@ ParticleSet::~ParticleSet() noexcept
 { }
 
 
-ParticleSet::~ParticleSet() noexcept { }
+void ParticleSet::resize(const std::size_t components, const std::size_t dim_linear, const std::size_t dim_circular)
+{
+    std::size_t new_dim = dim_linear + dim_circular;
+
+    if ((this->dim_linear == dim_linear) && (this->dim_circular = dim_circular) && (this->components == components))
+        return;
+    else if ((this->dim == new_dim) && (this->components != components))
+        state_.conservativeResize(NoChange, components);
+    else
+    {
+        // In any other case, it does not make sense to do conservative resize
+        // since either old data is truncated or new data is incomplete
+        state_.resize(new_dim, components);
+    }
+
+    GaussianMixture::resize(components, dim_linear, dim_circular);
+}
 
 
 ParticleSet& ParticleSet::operator+=(const ParticleSet& rhs)

--- a/test/test_Gaussian/main.cpp
+++ b/test/test_Gaussian/main.cpp
@@ -65,7 +65,105 @@ int main()
         else
             std::cout << "Default initialization of Gaussian covariance is 1.0: " << gaussian_1d.weight() << std::endl;
 
-        std::cout << "done!\n" << std::endl;
+
+        std::cout << "Increase size of Gaussian by one:" << std::endl;
+        gaussian_1d.resize(1 + 1);
+        if (gaussian_1d.components != 1)
+        {
+            std::cout << "Resize of Gaussian failed, number of components is " << gaussian_1d.components << ", should be 1" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (gaussian_1d.dim_linear != 2)
+        {
+            std::cout << "Resize of Gaussian failed, linear dimension is " << gaussian_1d.dim_linear << ", should be 2" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (gaussian_1d.dim_circular != 0)
+        {
+            std::cout << "Resize of Gaussian failed, circular dimension is " << gaussian_1d.dim_circular << ", should be 0" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (!((gaussian_1d.mean().rows() == 2) && (gaussian_1d.mean().cols() == 1)))
+        {
+            std::cout << "Resize of Gaussian failed, mean size is "
+                      << gaussian_1d.mean().rows() << " x " << gaussian_1d.mean().cols()
+                      << ", should be 2 x 1" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (!((gaussian_1d.covariance().rows() == 2) && (gaussian_1d.covariance().cols() == 2)))
+        {
+            std::cout << "Resize of Gaussian failed, mean size is "
+                      << gaussian_1d.mean().rows() << " x " << gaussian_1d.mean().cols()
+                      << ", should be 2 x 2" << std::endl;
+            return EXIT_FAILURE;
+        }
+        std::cout << "ok." << std::endl;
+
+
+        std::cout << "Change sizes without changing total size, i.e. (linear, circular) = (0, 2):" << std::endl;
+        gaussian_1d.resize(0, 2);
+        if (gaussian_1d.components != 1)
+        {
+            std::cout << "Resize of Gaussian failed, number of components is " << gaussian_1d.components << ", should be 1" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (gaussian_1d.dim_linear != 0)
+        {
+            std::cout << "Resize of Gaussian failed, linear dimension is " << gaussian_1d.dim_linear << ", should be 0" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (gaussian_1d.dim_circular != 2)
+        {
+            std::cout << "Resize of Gaussian failed, circular dimension is " << gaussian_1d.dim_circular << ", should be 2" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (!((gaussian_1d.mean().rows() == 2) && (gaussian_1d.mean().cols() == 1)))
+        {
+            std::cout << "Resize of Gaussian failed, mean size is "
+                      << gaussian_1d.mean().rows() << " x " << gaussian_1d.mean().cols()
+                      << ", should be 2 x 1" << std::endl;
+        }
+        if (!((gaussian_1d.covariance().rows() == 2) && (gaussian_1d.covariance().cols() == 2)))
+        {
+            std::cout << "Resize of Gaussian failed, mean size is "
+                      << gaussian_1d.mean().rows() << " x " << gaussian_1d.mean().cols()
+                      << ", should be 2 x 2" << std::endl;
+        }
+        std::cout << "ok." << std::endl;
+
+
+        std::cout << "Change size to (linear, circular) = (2, 2):" << std::endl;
+        gaussian_1d.resize(2, 2);
+        if (gaussian_1d.components != 1)
+        {
+            std::cout << "Resize of Gaussian failed, number of components is " << gaussian_1d.components << ", should be 1" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (gaussian_1d.dim_linear != 2)
+        {
+            std::cout << "Resize of Gaussian failed, linear dimension is " << gaussian_1d.dim_linear << ", should be 2" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (gaussian_1d.dim_circular != 2)
+        {
+            std::cout << "Resize of Gaussian failed, circular dimension is " << gaussian_1d.dim_circular << ", should be 2" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (!((gaussian_1d.mean().rows() == 4) && (gaussian_1d.mean().cols() == 1)))
+        {
+            std::cout << "Resize of Gaussian failed, mean size is "
+                      << gaussian_1d.mean().rows() << " x " << gaussian_1d.mean().cols()
+                      << ", should be 4 x 1" << std::endl;
+        }
+        if (!((gaussian_1d.covariance().rows() == 4) && (gaussian_1d.covariance().cols() == 4)))
+        {
+            std::cout << "Resize of Gaussian failed, mean size is "
+                      << gaussian_1d.mean().rows() << " x " << gaussian_1d.mean().cols()
+                      << ", should be 4 x 4" << std::endl;
+        }
+        std::cout << "ok." << std::endl;
+
+        std::cout << "...done!\n" << std::endl;
     }
 
 
@@ -174,6 +272,8 @@ int main()
         }
         else
             std::cout << "Assignment of Gaussian weight successful:\n" << gaussian_3d_move.weight() << std::endl;
+
+        std::cout << "...done!\n" << std::endl;
     }
 
 
@@ -222,6 +322,8 @@ int main()
         }
         else
             std::cout << "Covariance of augmented gaussian evaluated successful:\n" << gaussian.covariance() << std::endl;
+
+        std::cout << "...done!\n" << std::endl;
     }
 
 
@@ -304,7 +406,6 @@ int main()
 
         std::cout << "done!\n" << std::endl;
 
-
         std::cout << "Reading values altogether to the Gaussian mixture with 5 3D components..." << std::endl;
 
         std::cout << "Means:\n" << gaussian_mixture.mean() << std::endl;
@@ -312,6 +413,184 @@ int main()
         std::cout << "Weights:\n" << gaussian_mixture.weight() << std::endl;
 
         std::cout << "done!\n" << std::endl;
+
+        std::cout << "Add one component to the Gaussian mixture with 5 3D components..." << std::endl;
+        GaussianMixture gaussian_mixture_copy = gaussian_mixture;
+
+        gaussian_mixture.resize(5 + 1, 3);
+        if (gaussian_mixture.components != 6)
+        {
+            std::cerr << "Resize of Gaussian Mixture failed, number of components is "
+                      << gaussian_mixture.components
+                      << ", should be 6" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (gaussian_mixture.dim_linear != 3)
+        {
+            std::cerr << "Resize of Gaussian Mixture failed, linear dimension is "
+                      << gaussian_mixture.dim_linear
+                      << ", should be 3" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (gaussian_mixture.dim_circular != 0)
+        {
+            std::cerr << "Resize of Gaussian Mixture failed, circular dimension is "
+                      << gaussian_mixture.dim_circular
+                      << ", should be 0" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (!((gaussian_mixture.mean().rows() == 3) && (gaussian_mixture.mean().cols() == 6)))
+        {
+            std::cerr << "Resize of Gaussian Mixture failed, mean size is "
+                      << gaussian_mixture.mean().rows() << " x " << gaussian_mixture.mean().cols()
+                      << ", should be 3 x 6" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (!((gaussian_mixture.covariance().rows() == 3) && (gaussian_mixture.covariance().cols() == 3 * 6)))
+        {
+            std::cerr << "Resize of Gaussian Mixture failed, covariance size is "
+                      << gaussian_mixture.covariance().rows() << " x " << gaussian_mixture.covariance().cols()
+                      << ", should be 3 x 18" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (gaussian_mixture.weight().size() != 6)
+        {
+            std::cerr << "Resize of Gaussian Mixture failed, weight size is "
+                      << gaussian_mixture.weight().size()
+                      << ", should be 6" << std::endl;
+            return EXIT_FAILURE;
+        }
+
+        /* When increasing the number of components and not changing the dimensions, the old content should be preserved */
+        if (!gaussian_mixture.mean().leftCols<5>().isApprox(gaussian_mixture_copy.mean()))
+        {
+            std::cerr << "Resize of Gaussian Mixture while maintaing dimensions failed, old mean content is" << std::endl
+                      << gaussian_mixture.mean().leftCols<5>() << std::endl
+                      << "should be" << std::endl
+                      << gaussian_mixture_copy.mean() << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (!gaussian_mixture.covariance().leftCols<15>().isApprox(gaussian_mixture_copy.covariance()))
+        {
+            std::cerr << "Resize of Gaussian Mixture while maintaing dimensions failed, old covariance content is" << std::endl
+                      << gaussian_mixture.covariance().leftCols<15>() << std::endl
+                      << "should be" << std::endl
+                      << gaussian_mixture_copy.covariance() << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (!gaussian_mixture.weight().head<5>().isApprox(gaussian_mixture_copy.weight()))
+        {
+            std::cerr << "Resize of Gaussian Mixture while maintaing dimensions failed, old weight content is" << std::endl
+                      << gaussian_mixture.weight().head<5>() << std::endl
+                      << "should be" << std::endl
+                      << gaussian_mixture_copy.weight() << std::endl;
+            return EXIT_FAILURE;
+        }
+        std::cout << "ok." << std::endl;
+
+        std::cout << "Showing comparison between original and augmented Gaussian Mixture..." << std::endl;
+
+        std::cout << "Means (original):\n" << gaussian_mixture_copy.mean() << std::endl;
+        std::cout << "Means (augmented):\n" << gaussian_mixture.mean() << std::endl;
+        std::cout << "Covariances (original):\n" << gaussian_mixture_copy.covariance() << std::endl;
+        std::cout << "Covariances (augmented):\n" << gaussian_mixture.covariance() << std::endl;
+        std::cout << "Weights (original):\n" << gaussian_mixture_copy.weight() << std::endl;
+        std::cout << "Weights (augmented):\n" << gaussian_mixture.weight() << std::endl;
+
+        std::cout << "Change sizes without changing total size, i.e. (linear, circular) = (0, 3):" << std::endl;
+        gaussian_mixture.resize(6, 0, 3);
+        if (gaussian_mixture.components != 6)
+        {
+            std::cerr << "Resize of Gaussian Mixture failed, number of components is "
+                      << gaussian_mixture.components
+                      << ", should be 6" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (gaussian_mixture.dim_linear != 0)
+        {
+            std::cerr << "Resize of Gaussian Mixture failed, linear dimension is "
+                      << gaussian_mixture.dim_linear
+                      << ", should be 0" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (gaussian_mixture.dim_circular != 3)
+        {
+            std::cerr << "Resize of Gaussian Mixture failed, circular dimension is "
+                      << gaussian_mixture.dim_circular
+                      << ", should be 3" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (!((gaussian_mixture.mean().rows() == 3) && (gaussian_mixture.mean().cols() == 6)))
+        {
+            std::cerr << "Resize of Gaussian Mixture failed, mean size is "
+                      << gaussian_mixture.mean().rows() << " x " << gaussian_mixture.mean().cols()
+                      << ", should be 3 x 6" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (!((gaussian_mixture.covariance().rows() == 3) && (gaussian_mixture.covariance().cols() == 3 * 6)))
+        {
+            std::cerr << "Resize of Gaussian Mixture failed, covariance size is "
+                      << gaussian_mixture.covariance().rows() << " x " << gaussian_mixture.covariance().cols()
+                      << ", should be 3 x 18" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (gaussian_mixture.weight().size() != 6)
+        {
+            std::cerr << "Resize of Gaussian Mixture failed, weight size is "
+                      << gaussian_mixture.weight().size()
+                      << ", should be 6" << std::endl;
+            return EXIT_FAILURE;
+        }
+        std::cout << "ok." << std::endl;
+
+
+        std::cout << "Change size to (linear, circular) = (3, 3):" << std::endl;
+        gaussian_mixture.resize(6, 3, 3);
+        if (gaussian_mixture.components != 6)
+        {
+            std::cerr << "Resize of Gaussian Mixture failed, number of components is "
+                      << gaussian_mixture.components
+                      << ", should be 6" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (gaussian_mixture.dim_linear != 3)
+        {
+            std::cerr << "Resize of Gaussian Mixture failed, linear dimension is "
+                      << gaussian_mixture.dim_linear
+                      << ", should be 3" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (gaussian_mixture.dim_circular != 3)
+        {
+            std::cerr << "Resize of Gaussian Mixture failed, circular dimension is "
+                      << gaussian_mixture.dim_circular
+                      << ", should be 3" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (!((gaussian_mixture.mean().rows() == 6) && (gaussian_mixture.mean().cols() == 6)))
+        {
+            std::cerr << "Resize of Gaussian Mixture failed, mean size is "
+                      << gaussian_mixture.mean().rows() << " x " << gaussian_mixture.mean().cols()
+                      << ", should be 6 x 6" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (!((gaussian_mixture.covariance().rows() == 6) && (gaussian_mixture.covariance().cols() == 6 * 6)))
+        {
+            std::cerr << "Resize of Gaussian Mixture failed, covariance size is "
+                      << gaussian_mixture.covariance().rows() << " x " << gaussian_mixture.covariance().cols()
+                      << ", should be 6 x 36" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (gaussian_mixture.weight().size() != 6)
+        {
+            std::cerr << "Resize of Gaussian Mixture failed, weight size is "
+                      << gaussian_mixture.weight().size()
+                      << ", should be 6" << std::endl;
+            return EXIT_FAILURE;
+        }
+        std::cout << "ok." << std::endl;
+
+        std::cout << "...done!\n" << std::endl;
     }
 
 


### PR DESCRIPTION
Within this PR:
- implemented virtual method `GaussianMixture::resize` that allows changing the number of components of a Gaussian mixture, the linear dimension and the circular dimension. When only the number of components is changed and it is higher than the old one, the method will perform a conservative resize in order not to lose the old data - since in this case it is clear how to preserve old data. Instead, if one of the dimensions is changed a normal resize is performed - since in this case either the old data is truncated or the new `means` and `covariances` would contain incomplete data
- implemented method `ParticleSet::resize` overriding `GaussianMixture::resize`. This method calls `GaussianMixture::resize` and is responsible for the resize of the storage containing the particles positions
- implemented method `Gaussian::resize`
- updated `test_Gaussian`
- updated `CHANGELOG.md`

Closes #48 