### PR TITLE
Implement Gaussian density with special covariance factorization and related

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Implemented method ParticleSet::resize().
 - Implemented evaluation of a multivariate Gaussian probability density function in method utils::multivariate_gaussian_density.
 - Implemented evaluation of the logarithm of a multivariate Gaussian probability density function in method utils::multivariate_gaussian_log_density.
+- Implemented evaluation of a multivariate Gaussian probability density function with UVR factorized covariance matrix in method `utils::multivariate_gaussian_density_UVR()`.
+- Implemented evaluation of the logarithm of a multivariate Gaussian probability density function with UVR factorized covariance matrix in method `utils::multivariate_gaussian_log_density_UVR()`.
 - Methods EstimatesExtraction::extract() return a std::pair containing a boolean indicating if the estimate is valid and the estracted estimate.
 - Methods EstimatesExtraction::extract() assume that particle weights are in the log space.
 - Constructor HistoryBuffer::HistoryBuffer() takes the state size.
@@ -28,6 +30,7 @@
 - Implemented method KFCorrection::getLikelihood().
 - Implemented method UKFPrediction::getStateModel().
 - Implemented method UKFCorrection::getLikelihood().
+- Implemented method `SUKFCorrection::getLikelihood()`.
 - Changed implementation of GaussianLikelihood::likelihood().
 - Changed implementation of GPFPrediction::getStateModel().
 - Changed implementation of GPFCorrection::getLikelihood().
@@ -42,6 +45,7 @@
 - Add mean extraction and logging in test_SIS to simplify inspection of the algorithm outcome.
 - Reduce number of particles in test_SIS to reduce testing computation time in Debug.
 - Add testUPF_MAP testing MAP (maximum a posteriori) estimate extraction within a UPF particle filter.
+- Add `test_Gaussian_Density_UVR` testing the method `utils::multivariate_gaussian_density_UVR()`.
 - Change test_Gaussian in order to test resizing.
 
 ## 🔖 Version 0.8.101

--- a/src/BayesFilters/include/BayesFilters/SUKFCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/SUKFCorrection.h
@@ -51,6 +51,8 @@ public:
 
     MeasurementModel& getMeasurementModel() override;
 
+    std::pair<bool, Eigen::VectorXd> getLikelihood() override;
+
 protected:
     void correctStep(const GaussianMixture& pred_state, GaussianMixture& corr_state) override;
 
@@ -58,6 +60,10 @@ protected:
 
 private:
     std::unique_ptr<MeasurementModel> measurement_model_;
+
+    Eigen::MatrixXd propagated_sigma_points_;
+
+    Eigen::MatrixXd innovations_;
 
     /**
      * Unscented transform weight.

--- a/src/BayesFilters/include/BayesFilters/utils.h
+++ b/src/BayesFilters/include/BayesFilters/utils.h
@@ -84,6 +84,102 @@ Eigen::VectorXd multivariate_gaussian_log_density(const Eigen::MatrixBase<Derive
 
 
 /**
+ * Evaluate the logarithm of a multivariate Gaussian probability density function
+ * using the Sherman–Morrison–Woodbury identity.
+ *
+ * It is assumed that the covariance matrix S can be written in the form S = UV + R
+ * where R is an invertible block diagonal matrix. Each block R_{i} is square and has
+ * dimension M such that N * M is the size of the input for some positive integer N.
+ *
+ * This version is much faster than the standard gaussian logarithm density evaluation
+ * if U.cols() << U.rows().
+ *
+ * @param input Input representing the argument of the function as a vector or matrix.
+ * @param mean The mean of the associated Gaussian distribution as a vector.
+ * @param U The U factor within the covariance matrix S = UV + R of the associated Gaussian distribution as a matrix.
+ * @param V The V factor within the covariance matrix S = UV + R of the associated Gaussian distribution as a matrix.
+ * @param R The R summand within the covariance matrix S = UV + R of the associated Gaussian distribuion as a matrix.
+ *          The matrix R has size M * (N * M) and consists in the concatenation of all the diagonal blocks R_{i}.
+ *          If the diagonal blocks are all equal, it is possible to provide a single M * M block matrix.
+ *
+ * @return The value of the logarithm of the density function evaluated on the input data as a vector.
+ */
+template<typename Derived>
+Eigen::VectorXd multivariate_gaussian_log_density_UVR(const Eigen::MatrixBase<Derived>& input, const Eigen::Ref<const Eigen::VectorXd>& mean, const Eigen::Ref<const Eigen::MatrixXd>& U, const Eigen::Ref<const Eigen::MatrixXd>& V, const Eigen::Ref<const Eigen::MatrixXd>& R)
+{
+    std::size_t input_size = input.rows();
+    std::size_t block_size = R.rows();
+    std::size_t num_blocks = input_size / block_size;
+
+    const auto diff = input.colwise() - mean;
+
+    // Evaluate inv(R)
+    Eigen::MatrixXd inv_R(block_size, input_size);
+    if (R.cols() == block_size)
+    {
+        // The diagonal blocks of R are all equal
+        Eigen::MatrixXd inv_R_single = R.inverse();
+        for (std::size_t i = 0; i < num_blocks; i++)
+        {
+            inv_R.block(0, block_size * i, block_size, block_size) = inv_R_single;
+        }
+    }
+    else
+    {
+        // The diagonal blocks of R are different
+        for (std::size_t i = 0; i < num_blocks; i++)
+        {
+            inv_R.block(0, block_size * i, block_size, block_size) = R.block(0, block_size * i, block_size, block_size).inverse();
+        }
+    }
+
+    // Evaluate V * inv(R)
+    Eigen::MatrixXd V_inv_R(V.rows(), V.cols());
+    for (std::size_t i = 0; i < V.cols() / block_size; i++)
+    {
+        V_inv_R.middleCols(i * block_size, block_size) = V.middleCols(i * block_size, block_size) * inv_R.block(0, block_size * i, block_size, block_size);
+    }
+
+    // Evaluate diff^{T} * inv(R)
+    Eigen::MatrixXd diff_T_inv_R(input.cols(), input.rows());
+    for (std::size_t i = 0; i < num_blocks; i++)
+    {
+        diff_T_inv_R.middleCols(i * block_size, block_size) = diff.middleRows(i * block_size, block_size).transpose() * inv_R.block(0, block_size * i, block_size, block_size);
+    }
+
+    // Evaluate I + V * inv(R) * U
+    Eigen::MatrixXd I_V_inv_R_U = Eigen::MatrixXd::Identity(V.rows(), V.rows()) + V_inv_R * U;
+
+    // Evaluate diff ^{T} * inv(S) * diff
+    // According to Sherman–Morrison–Woodbury formula inv(S) = inv(UV + R) = inv(R)(I - U inv(I + V inv(R) U) V inv(R))
+    // See https://en.wikipedia.org/wiki/Woodbury_matrix_identity
+    Eigen::VectorXd weighted_diffs(input.cols());
+    for (std::size_t i = 0; i < weighted_diffs.size(); i++)
+        weighted_diffs(i) = diff_T_inv_R.row(i) * (Eigen::MatrixXd::Identity(U.rows(), U.rows()) - U * I_V_inv_R_U.inverse() * V_inv_R) * diff.col(i);
+
+    // Evalute determinant(S)
+    // According to Generalized matrix determinant lemma det(S) = det(UV + R) = det(R) det(I + V inv(R) U)
+    // See https://en.wikipedia.org/wiki/Matrix_determinant_lemma#Generalization
+    double det_S;
+    double det_R = 1.0;
+    if (R.cols() == block_size)
+        det_R = std::pow(R.determinant(), num_blocks);
+    else
+        for (std::size_t i = 0; i < num_blocks; i++)
+            det_R *= R.block(0, block_size * i, block_size, block_size).determinant();
+
+    det_S = det_R * I_V_inv_R_U.determinant();
+
+    // Evaluate the full logarithm density
+    Eigen::VectorXd values(input.cols());
+    for (std::size_t i = 0; i < input.cols(); i++)
+        values(i) = - 0.5 * (static_cast<double>(diff.rows()) * std::log(2.0 * M_PI) + std::log(det_S) + weighted_diffs(i));
+
+    return values;
+}
+
+
+/**
  * Evaluate a multivariate Gaussian probability density function.
  *
  * @param input Input representing the argument of the function as a vector or matrix.

--- a/src/BayesFilters/include/BayesFilters/utils.h
+++ b/src/BayesFilters/include/BayesFilters/utils.h
@@ -196,6 +196,34 @@ Eigen::VectorXd multivariate_gaussian_density(const Eigen::MatrixBase<Derived>& 
 
 
 /**
+ * Evaluate the logarithm of a multivariate Gaussian probability density function
+ * using the Sherman–Morrison–Woodbury formula.
+ *
+ * It is assumed that the covariance matrix S can be written in the form S = UV + R
+ * where R is an invertible block diagonal matrix. Each block R_{i} is square and has
+ * dimension M such that N * M is the size of the input for some positive integer N.
+ *
+ * This version is much faster than the standard gaussian density evaluation
+ * if U.cols() << U.rows().
+ *
+ * @param input Input representing the argument of the function as a vector or matrix.
+ * @param mean The mean of the associated Gaussian distribution as a vector.
+ * @param U The U factor within the covariance matrix S = UV + R of the associated Gaussian distribution as a matrix.
+ * @param V The V factor within the covariance matrix S = UV + R of the associated Gaussian distribution as a matrix.
+ * @param R The R summand within the covariance matrix S = UV + R of the associated Gaussian distribuion as a matrix.
+ *          The matrix R has size M * (N * M) and consists in the concatenation of all the diagonal blocks R_{i}.
+ *          If the diagonal blocks are all equal, it is possible to provide a single M * M block matrix.
+ *
+ * @return The value of the density function evaluated on the input data as a vector.
+ */
+template<typename Derived>
+Eigen::VectorXd multivariate_gaussian_density_UVR(const Eigen::MatrixBase<Derived>& input, const Eigen::Ref<const Eigen::VectorXd>& mean, const Eigen::Ref<const Eigen::MatrixXd>& U, const Eigen::Ref<const Eigen::MatrixXd>& V, const Eigen::Ref<const Eigen::MatrixXd>& R)
+{
+    return multivariate_gaussian_log_density_UVR(input, mean, U, V, R).array().exp();
+}
+
+
+/**
  * This template class provides methods to keep track of time. The default time unit is milliseconds,
  * but can be changed during object creation using a different std::chrono::duration type.
  * See https://en.cppreference.com/w/cpp/chrono/duration for reference.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ option(TEST_LOG_TO_FILE "Write test logs to file" OFF)
 
 add_subdirectory(test_DirectionalStatisticsUtils)
 add_subdirectory(test_Gaussian)
+add_subdirectory(test_Gaussian_Density_UVR)
 add_subdirectory(test_SigmaPointUtils)
 add_subdirectory(test_SIS)
 add_subdirectory(test_SIS_Decorators)

--- a/test/test_Gaussian_Density_UVR/CMakeLists.txt
+++ b/test/test_Gaussian_Density_UVR/CMakeLists.txt
@@ -1,0 +1,22 @@
+#===============================================================================
+#
+# Copyright (C) 2016-2019 Istituto Italiano di Tecnologia (IIT)
+#
+# This software may be modified and distributed under the terms of the
+# BSD 3-Clause license. See the accompanying LICENSE file for details.
+#
+#===============================================================================
+
+set(TEST_TARGET_NAME test_Gaussian_Density_UVR)
+
+set(${TEST_TARGET_NAME}_SRC
+        main.cpp
+)
+
+add_executable(${TEST_TARGET_NAME} ${${TEST_TARGET_NAME}_SRC})
+
+target_link_libraries(${TEST_TARGET_NAME} BayesFilters)
+
+add_test(NAME ${TEST_TARGET_NAME}
+         COMMAND ${TEST_TARGET_NAME}
+         WORKING_DIRECTORY $<TARGET_FILE_DIR:${TEST_TARGET_NAME}>)

--- a/test/test_Gaussian_Density_UVR/main.cpp
+++ b/test/test_Gaussian_Density_UVR/main.cpp
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2016-2019 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <BayesFilters/Gaussian.h>
+#include <BayesFilters/GaussianMixture.h>
+#include <BayesFilters/AdditiveMeasurementModel.h>
+#include <BayesFilters/sigma_point.h>
+#include <BayesFilters/utils.h>
+
+#include <Eigen/Dense>
+
+#include <iostream>
+
+using namespace Eigen;
+using namespace bfl;
+
+
+class SimulatedMeasurement : public AdditiveMeasurementModel
+{
+public:
+    SimulatedMeasurement(const Ref<VectorXd>& measurement, const Ref<VectorXd>& predicted_measurement) :
+        measurement_(measurement), predicted_measurement_(predicted_measurement)
+    { }
+
+
+    bool freeze() override
+    {
+        return true;
+    }
+
+
+    std::pair<bool, Data> measure(const Data& data = Data()) const override
+    {
+        MatrixXd measurement(measurement_.size(), 1);
+        measurement.col(0) = measurement_;
+        return std::make_pair(true, measurement);
+    }
+
+
+    std::pair<bool, Data> predictedMeasure(const Ref<const MatrixXd>& cur_states) const override
+    {
+        MatrixXd predicted = MatrixXd::Zero(measurement_.size(), cur_states.cols());
+        predicted.colwise() += predicted_measurement_;
+        return std::make_pair(true, predicted);
+    }
+
+
+    std::pair<bool, Data> innovation(const Data& predicted_measurements, const Data& measurements) const override
+    {
+        MatrixXd innovation = -(any::any_cast<MatrixXd>(predicted_measurements).colwise() - any::any_cast<MatrixXd>(measurements).col(0));
+
+        return std::make_pair(true, std::move(innovation));
+    }
+
+
+    std::pair<bool, MatrixXd> getNoiseCovarianceMatrix() const
+    {
+        VectorXd covariance(measurement_.size());
+        for (std::size_t i = 0; i < measurement_.size(); i++)
+            covariance(i) = 0.1 * (i + 1);
+
+        MatrixXd covariance_matrix = covariance.asDiagonal();
+
+        return std::make_pair(true, covariance_matrix);
+    }
+
+
+    std::pair<std::size_t, std::size_t> getOutputSize() const override
+    {
+        return std::pair<int, int>(measurement_.size(), 0);
+    }
+
+private:
+    VectorXd measurement_;
+
+    VectorXd predicted_measurement_;
+};
+
+
+int main()
+{
+    std::cout << "[Test] " << std::endl;
+    {
+        std::cout << "Constructing a simulated scenario..." << std::endl;
+
+        // Unscented Transform parameters
+        double alpha = 1.0;
+        double beta = 2.0;
+        double kappa = 0.0;
+        sigma_point::UTWeight ut_weight(3, alpha, beta, kappa);
+
+        // Predicted state
+        Gaussian predicted_state(3);
+        Matrix3d covariance;
+        covariance << 0.01, 0.0,  0.0,
+                      0.0,  0.01, 0.0,
+                      0.0,  0.0,  0.01;
+        predicted_state.mean() = Vector3d::Zero();
+        predicted_state.covariance() = covariance;
+
+        // Measurement model
+        VectorXd measurement(6);
+        measurement(0) = 1.05;
+        measurement(1) = -0.05;
+        measurement(2) = 0.05;
+        measurement(3) = 0.95;
+        measurement(4) = 1.1;
+        measurement(5) = 0.8;
+
+        VectorXd predicted(6);
+        predicted(0) = 1.0;
+        predicted(1) = 0.0;
+        predicted(2) = 0.0;
+        predicted(3) = 1.0;
+        predicted(4) = 1.0;
+        predicted(5) = 1.0;
+
+        SimulatedMeasurement measurement_model(measurement, predicted);
+
+        // Propagate belief
+        GaussianMixture predicted_measurement(1, 6);
+        MatrixXd cross_covariance;
+        std::tie(std::ignore, predicted_measurement, cross_covariance) = sigma_point::unscented_transform(predicted_state, ut_weight, measurement_model);
+
+        // Extract mean and predicted measurement covariance
+        VectorXd my = predicted_measurement.mean(0);
+        MatrixXd Py = predicted_measurement.covariance(0);
+
+        std::cout << "done." << std::endl;
+
+        // Evaluate likelihood using standard Gaussian
+        VectorXd likelihood_0 = utils::multivariate_gaussian_density(measurement, my, Py);
+
+        std::cout << "Evaluated likelihood using standard Gaussian evaluation is " << likelihood_0(0) << std::endl;
+
+        // Evaluate likelihood using Gaussian having covariance in the form S = UV + R with R block diagonal
+
+        // Evaluate the predicted measurement covariance using the form Py = YY^{T} + R with U = Y, V = Y^{T}
+        MatrixXd input_sigma_points = sigma_point::sigma_point(predicted_state, ut_weight.c);
+
+        bfl::Data prediction;
+        std::tie(std::ignore, prediction) = measurement_model.predictedMeasure(input_sigma_points);
+        MatrixXd propagated_sigma_points = bfl::any::any_cast<MatrixXd&&>(std::move(prediction));
+
+        MatrixXd sqrt_ut_weight = ut_weight.covariance.array().sqrt().matrix().asDiagonal();
+        MatrixXd Y = propagated_sigma_points.colwise() - my;
+        Y *= sqrt_ut_weight;
+
+        MatrixXd R_full;
+        std::tie(std::ignore, R_full) = measurement_model.getNoiseCovarianceMatrix();
+
+        // Compose the R matrix with adjacent diagonal blocks, as required by the method
+        // utils::multivariate_gaussian_UVR()
+        MatrixXd R(2, 6);
+        for (std::size_t i = 0; i < R_full.cols() / 2; i++)
+            R.block<2, 2>(0, 2 * i) = R_full.block<2, 2>(2 * i, 2 * i);
+
+        VectorXd likelihood_1 = utils::multivariate_gaussian_density_UVR(measurement, my, Y, Y.transpose(), R);
+        std::cout << "Evaluated likelihood using Gaussian with UVR factorized covariance matrix is " << likelihood_1(0) << std::endl;
+
+        if (!(std::abs(likelihood_0(0) - likelihood_1(0)) < 0.00001))
+        {
+            std::cerr << "Evaluation of likelihood using Gaussian with UVR factorized covariance matrix failed."
+                      << "Should be " << likelihood_0(0) << ", is " << likelihood_1(0) << std::endl;
+            return EXIT_FAILURE;
+        }
+    }
+
+    std::cout << "done." << std::endl;
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Within this PR:
- implemented a utility function, `utils::multivariate_gaussian_density_UVR`, for evaluation of a multivariate Gaussian probability density in case of a covariance of the form `S = UV + R` with `R` a block diagonal matrix;
> This method is useful when `cols(U) << rows(U) = N`, where `N` is the size of the input to the Gaussian density, since it avoids inverting a `rows(U) x rows(U)` matrix and evaluating the determinant of the same matrix. Instead, by using the `Sherman-Morrison-Woodbury` identity, it inverts a matrix having size `cols(U) x cols(U)`.
As an example, in the context of `UKF` filtering with an additive measurement model, the predicted measurement covariance can be written as `S = UV + R = YY^{T} + R` with `Y` a matrix containing the predicted measurements sigma points, shifted w.r.t to the predicted mean and scaled using the square root of the unscented transform weights. In this case, `rows(Y)` is the number of measurements while `cols(Y)` is equal to `2 x n + 1` where `n` is the size of the state vector. If the number of measurements is much greater than `2 x n + 1`, then the condition `cols(U) << rows(U)` is verified.
- implemented method `SUKFCorrection::getLikelihood` using `utils::multivariate_gaussian_density_UVR`;
- added test `test_Gaussian_High_Dimensional` testing method `utils::multivariate_gaussian_density_UVR`;
- updated `CHANGELOG.md`.

This closes #61 