### PR TITLE
Add input argument of type Data to MeasurementModel::freeze()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Fixed missing const(s) keywords in signature of method StateModel::getTransitionProbability().
 - Fixed missing const(s) keywords in signature of method WhiteNoiseAcceleration::getTransitionProbability().
 - SUKFCorrection::getNoiseCovarianceMatrix() is now virtual.
+- Method MeasurementModel::freeze() takes an input argument of type Data.
 
 ##### `Test`
 - Mean extraction is performed using EstimatesExtraction utilities in test_UPF.

--- a/src/BayesFilters/include/BayesFilters/MeasurementModel.h
+++ b/src/BayesFilters/include/BayesFilters/MeasurementModel.h
@@ -27,7 +27,7 @@ class bfl::MeasurementModel : public Logger
 public:
     virtual ~MeasurementModel() noexcept;
 
-    virtual bool freeze() = 0;
+    virtual bool freeze(const Data& data = Data()) = 0;
 
     virtual std::pair<bool, Data> measure(const Data& data = Data()) const = 0;
 

--- a/src/BayesFilters/include/BayesFilters/MeasurementModelDecorator.h
+++ b/src/BayesFilters/include/BayesFilters/MeasurementModelDecorator.h
@@ -30,7 +30,7 @@ public:
 
     bool setProperty(const std::string& property) override;
 
-    bool freeze() override;
+    bool freeze(const Data& data = Data()) override;
 
     std::pair<std::size_t, std::size_t> getOutputSize() const override;
 

--- a/src/BayesFilters/include/BayesFilters/SimulatedLinearSensor.h
+++ b/src/BayesFilters/include/BayesFilters/SimulatedLinearSensor.h
@@ -29,7 +29,7 @@ public:
 
     virtual ~SimulatedLinearSensor() noexcept;
 
-    bool freeze() override;
+    bool freeze(const Data& data = Data()) override;
 
     std::pair<bool, bfl::Data> measure(const Data& data = Data()) const override;
 

--- a/src/BayesFilters/src/MeasurementModelDecorator.cpp
+++ b/src/BayesFilters/src/MeasurementModelDecorator.cpp
@@ -60,7 +60,7 @@ bool MeasurementModelDecorator::setProperty(const std::string& property)
 }
 
 
-bool MeasurementModelDecorator::freeze()
+bool MeasurementModelDecorator::freeze(const Data& data)
 {
     return measurement_model->freeze();
 }

--- a/src/BayesFilters/src/SimulatedLinearSensor.cpp
+++ b/src/BayesFilters/src/SimulatedLinearSensor.cpp
@@ -63,7 +63,7 @@ SimulatedLinearSensor::~SimulatedLinearSensor() noexcept
 { }
 
 
-bool SimulatedLinearSensor::freeze()
+bool SimulatedLinearSensor::freeze(const Data& data)
 {
     if (!simulated_state_model_->bufferData())
         return false;

--- a/test/test_Gaussian_Density_UVR/main.cpp
+++ b/test/test_Gaussian_Density_UVR/main.cpp
@@ -27,7 +27,7 @@ public:
     { }
 
 
-    bool freeze() override
+    bool freeze(const Data& data) override
     {
         return true;
     }


### PR DESCRIPTION
Within this PR:
- added input argument of type `bfl::Data` to the signature of method `MeasurementModel::freeze()`;
- updated signature of methods `MeasurementModelDecorator::freeze()` and `SimulatedLinearSensor::freeze()` accordingly;
- updated test `test_Gaussian_Density_UVR` due to change to `MeasurementModel::freeze()`;
- updated `CHANGELOG.md`.