### PR TITLE
Do not freeze the measurements within correction methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,16 @@
 - Fixed missing const(s) keywords in signature of method WhiteNoiseAcceleration::getTransitionProbability().
 - SUKFCorrection::getNoiseCovarianceMatrix() is now virtual.
 - Method MeasurementModel::freeze() takes an input argument of type Data.
+- `PFCorrection::correct()` now does not perform measurements freeze before calling `PFCorrection::correctStep()`.
+- `GaussianCorrection::correct()` now does not perform measurements freeze before calling `GaussianCorrection::correctStep()`.
+- `GPFPrediction::predictStep()` calls `predict()` instead of `predictStep()` on the underlying `GaussianPrediction`.
+- `GPFPrediction::correctStep()` calls `correct()` instead of `correctStep()` on the underlying `GaussianCorrection`.
+- `GaussianPrediction` is not a friend of `GPFPrediction` anymore.
+- `GaussianCorrection` is not a friend of `GPFCorrection` anymore.
+
+##### `Filtering algorithms`
+- `SIS::filteringStep()` performs measurements freeze before performing the actual correction. The correction is skipped if the freeze fails. The user might want to re-implement this method (or provide their own algorithm) if they need to handle the measurements freeze differently.
+
 
 ##### `Test`
 - Mean extraction is performed using EstimatesExtraction utilities in test_UPF.
@@ -48,6 +58,7 @@
 - Add testUPF_MAP testing MAP (maximum a posteriori) estimate extraction within a UPF particle filter.
 - Add `test_Gaussian_Density_UVR` testing the method `utils::multivariate_gaussian_density_UVR()`.
 - Change test_Gaussian in order to test resizing.
+- Update `test_KF`, `test_UKF`, `test_mixed_KF_UKF`, `test_mixed_UKF_KF`, `test_mixed_KF_SUKF` to account for the removed measurements freeze within `GaussianCorrection::correct()`.
 
 ## 🔖 Version 0.8.101
 ##### `Bugfix`

--- a/src/BayesFilters/include/BayesFilters/GaussianCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/GaussianCorrection.h
@@ -40,10 +40,6 @@ protected:
 
 private:
     bool skip_ = false;
-
-    friend class GaussianCorrectionDecorator;
-
-    friend class GPFCorrection;
 };
 
 #endif /* GAUSSIANCORRECTION_H */

--- a/src/BayesFilters/include/BayesFilters/GaussianPrediction.h
+++ b/src/BayesFilters/include/BayesFilters/GaussianPrediction.h
@@ -49,10 +49,6 @@ private:
     bool skip_state_ = false;
 
     bool skip_exogenous_ = false;
-
-    friend class GaussianPredictionDecorator;
-
-    friend class GPFPrediction;
 };
 
 #endif /* GAUSSIANPREDICTION_H */

--- a/src/BayesFilters/src/GPFCorrection.cpp
+++ b/src/BayesFilters/src/GPFCorrection.cpp
@@ -86,7 +86,7 @@ std::pair<bool, Eigen::VectorXd> GPFCorrection::getLikelihood()
 void GPFCorrection::correctStep(const bfl::ParticleSet& pred_particles, bfl::ParticleSet& corr_particles)
 {
     /* Propagate Gaussian belief associated to each particle. */
-    gaussian_correction_->correctStep(pred_particles, corr_particles);
+    gaussian_correction_->correct(pred_particles, corr_particles);
 
     /* Sample from the proposal distribution. */
     for (std::size_t i = 0; i < pred_particles.components; i++)

--- a/src/BayesFilters/src/GPFPrediction.cpp
+++ b/src/BayesFilters/src/GPFPrediction.cpp
@@ -43,7 +43,7 @@ void GPFPrediction::predictStep(const bfl::ParticleSet& prev_particles, bfl::Par
     gaussian_prediction_->skip("exogenous", getSkipExogenous());
 
     /* Propagate Gaussian belief associated to each particle. */
-    gaussian_prediction_->predictStep(prev_particles, pred_particles);
+    gaussian_prediction_->predict(prev_particles, pred_particles);
 
     /* Copy particles weights since they do not change. */
     pred_particles.weight() = prev_particles.weight();

--- a/src/BayesFilters/src/GaussianCorrection.cpp
+++ b/src/BayesFilters/src/GaussianCorrection.cpp
@@ -17,7 +17,7 @@ GaussianCorrection::GaussianCorrection() noexcept { };
 void GaussianCorrection::correct(const GaussianMixture& pred_state, GaussianMixture& corr_state)
 {
     /* Perform correction if required and if measurements can be frozen. */
-    if ((!skip_) && getMeasurementModel().freeze())
+    if (!skip_)
         correctStep(pred_state, corr_state);
     else
         corr_state = pred_state;

--- a/src/BayesFilters/src/PFCorrection.cpp
+++ b/src/BayesFilters/src/PFCorrection.cpp
@@ -17,7 +17,7 @@ PFCorrection::PFCorrection() noexcept { };
 void PFCorrection::correct(const ParticleSet& pred_particles, ParticleSet& cor_particles)
 {
     /* Perform correction if required and if measurements can be frozen. */
-    if ((!skip_) && getMeasurementModel().freeze())
+    if (!skip_)
         correctStep(pred_particles, cor_particles);
     else
         cor_particles = pred_particles;

--- a/src/BayesFilters/src/SIS.cpp
+++ b/src/BayesFilters/src/SIS.cpp
@@ -89,10 +89,15 @@ void SIS::filteringStep()
     if (getFilteringStep() != 0)
         prediction_->predict(cor_particle_, pred_particle_);
 
-    correction_->correct(pred_particle_, cor_particle_);
+    if (correction_->getMeasurementModel().freeze())
+    {
+        correction_->correct(pred_particle_, cor_particle_);
 
-    /* Normalize weights using LogSumExp. */
-    cor_particle_.weight().array() -= utils::log_sum_exp(cor_particle_.weight());
+        /* Normalize weights using LogSumExp. */
+        cor_particle_.weight().array() -= utils::log_sum_exp(cor_particle_.weight());
+    }
+    else
+        cor_particle_ = pred_particle_;
 
     log();
 

--- a/test/test_KF/main.cpp
+++ b/test/test_KF/main.cpp
@@ -57,7 +57,10 @@ protected:
     void filteringStep() override
     {
         prediction_->predict(corrected_state_, predicted_state_);
-        correction_->correct(predicted_state_, corrected_state_);
+        if (correction_->getMeasurementModel().freeze())
+            correction_->correct(predicted_state_, corrected_state_);
+        else
+            corrected_state_ = predicted_state_;
 
         log();
     }

--- a/test/test_UKF/main.cpp
+++ b/test/test_UKF/main.cpp
@@ -58,7 +58,10 @@ protected:
     void filteringStep() override
     {
         prediction_->predict(corrected_state_, predicted_state_);
-        correction_->correct(predicted_state_, corrected_state_);
+        if (correction_->getMeasurementModel().freeze())
+            correction_->correct(predicted_state_, corrected_state_);
+        else
+            corrected_state_ = predicted_state_;
 
         log();
     }

--- a/test/test_mixed_KF_SUKF/main.cpp
+++ b/test/test_mixed_KF_SUKF/main.cpp
@@ -58,7 +58,10 @@ protected:
     void filteringStep() override
     {
         prediction_->predict(corrected_state_, predicted_state_);
-        correction_->correct(predicted_state_, corrected_state_);
+        if (correction_->getMeasurementModel().freeze())
+            correction_->correct(predicted_state_, corrected_state_);
+        else
+            corrected_state_ = predicted_state_;
 
         log();
     }

--- a/test/test_mixed_KF_UKF/main.cpp
+++ b/test/test_mixed_KF_UKF/main.cpp
@@ -58,7 +58,10 @@ protected:
     void filteringStep() override
     {
         prediction_->predict(corrected_state_, predicted_state_);
-        correction_->correct(predicted_state_, corrected_state_);
+        if (correction_->getMeasurementModel().freeze())
+            correction_->correct(predicted_state_, corrected_state_);
+        else
+            corrected_state_ = predicted_state_;
 
         log();
     }

--- a/test/test_mixed_UKF_KF/main.cpp
+++ b/test/test_mixed_UKF_KF/main.cpp
@@ -58,7 +58,10 @@ protected:
     void filteringStep() override
     {
         prediction_->predict(corrected_state_, predicted_state_);
-        correction_->correct(predicted_state_, corrected_state_);
+        if (correction_->getMeasurementModel().freeze())
+            correction_->correct(predicted_state_, corrected_state_);
+        else
+            corrected_state_ = predicted_state_;
 
         log();
     }


### PR DESCRIPTION
Within this PR:
- (1) avoid freezing the measurements in `PFCorrection::correct()` and `GaussianCorrection::correct()` as the user might want to perform this step in a different moment
- as a consequence of (1), `SIS::filteringStep()` freezes the measurement before calling the correction step
> Please note that `SIS` is the only actual filtering recipe that we provide in the library. As such, we need to enforce that the standard implementation of `SIS::filteringStep()` is sound, i.e. it freezes the measurements before calling the correction step. Of course, the user are free to override this method or provide their own filtering algorithm.
- as a consequence of (1), re-implement the overridden `filteringStep()` method in tests `test_KF`, `test_UKF`, `test_mixed_KF_UKF`, `test_mixed_UKF_KF`,` test_mixed_KF_SUKF`
- as a consequence of (1), remove the (ugly) friendship between classes `GaussianCorrection` and `GPFCorrection` (and, for completeness - even if not related to (1), between `GaussianPrediction` and `GPFPrediction`)
- update `CHANGELOG.md`