### PR TITLE
Implement quaternion utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
 - Renamed Logger::get_prefix_path() in Logger::get_folder_path().
 - Renamed Logger::get_prefix_name() in Logger::get_file_name_prefix().
 - Logger::enable_log() now requires absolute or relative paths as input.
+- Added method `bfl::utils::quaternion_to_rotation_vector()` that takes the logarithm of a unitary quaternion and return its imaginary part belonging to the tangent space, i.e. it is a rotation vector.
+- Added method `bfl::utils::rotation_vector_to_quaternion()` that takes the exponential of rotation vector, i.e. the associated unitary quaternion.
+- Added method `bfl::utils::sum_quaternion_rotation_vector()` that evaluates the colwise sum between a unitary quaternion and a set of rotation vectors. The i-th sum is obtained as the quaternion product between the exponential of the i-th rotation vector and the quaternion.
+- Added method `bfl::utils::diff_quaternion()` that evaluates the colwise difference between a set of quaternions and a given unitary quaternion (right operand). The i-th difference is obtained as the logarithm of the quaternion product between the i-th quaternion and the conjugated right operand, i.e it is a rotation vector.
+- Added method `bfl::utils::mean_quaternion()` that evaluates the weighted mean of a set of unitary quaternions.
 
 ##### `Filtering functions`
 - Added pure public virtual method GaussianPrediction::getStateModel() (required to properly implement GPFPrediction::getStateModel()).

--- a/src/BayesFilters/include/BayesFilters/utils.h
+++ b/src/BayesFilters/include/BayesFilters/utils.h
@@ -79,6 +79,24 @@ Eigen::MatrixXd quaternion_to_rotation_vector(const Eigen::Ref<const Eigen::Matr
 
 
 /**
+ *
+ * Convert a matrix of rotation vectors in the tangent space (in the form (rx, ry, rz))
+ * to their unitary quaternionic representation.
+ *
+ * Taken from
+ * Chiella, A. C., Teixeira, B. O., & Pereira, G. A. (2019).
+ * Quaternion-Based Robust Attitude Estimation Using an Adaptive Unscented Kalman Filter.
+ * Sensors, 19(10), 2372.
+ *
+ * @param rotation_vector, a 3 x N matrix each column of which is a rotation vector
+ *
+ * @return a 4 x N matrix each column of which is the unit quaternion associated to the input rotation vector
+ *
+ */
+Eigen::MatrixXd rotation_vector_to_quaternion(const Eigen::Ref<const Eigen::MatrixXd>& rotation_vector);
+
+
+/**
  * Evaluate the logarithm of a multivariate Gaussian probability density function.
  *
  * @param input Input representing the argument of the function as a vector or matrix.

--- a/src/BayesFilters/include/BayesFilters/utils.h
+++ b/src/BayesFilters/include/BayesFilters/utils.h
@@ -8,11 +8,8 @@
 /**
  * Header-only utility library implementing missing features.
  *
- * What: Possible implementation of std::make_unique.
- * Who:  Contributed by Claudio Fantacci.
- * When: July 2001, April 2013 - May 2013, September 2018.
- * Doc:  See https://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique.
- *       See also: https://herbsutter.com/gotw/_102/.
+ * Who:  Contributed by Claudio Fantacci, Nicola Piga.
+ * When: July 2001, April 2013 - May 2013, September 2018, February 2020
  *
  */
 #ifndef UTILS_H
@@ -40,6 +37,9 @@ namespace utils
  * allocate_unique would be required to invent the deleter type D for the
  * unique_ptr<T,D> it returns which would contain an allocator object and invoke
  * both destroy and deallocate in its operator().
+ *
+ * See https://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique.
+ * See also: https://herbsutter.com/gotw/_102/.
  *
  * @param args list of arguments with which an instance of T will be constructed.
  *

--- a/src/BayesFilters/include/BayesFilters/utils.h
+++ b/src/BayesFilters/include/BayesFilters/utils.h
@@ -135,6 +135,24 @@ Eigen::MatrixXd diff_quaternion(const Eigen::Ref<const Eigen::MatrixXd>& quatern
 
 
 /**
+ *
+ * Evaluate the weighted mean of a set of unit quaternions (in the form (w, x, y, z) = (w, n))
+ *
+ * Taken from
+ * Chiella, A. C., Teixeira, B. O., & Pereira, G. A. (2019).
+ * Quaternion-Based Robust Attitude Estimation Using an Adaptive Unscented Kalman Filter.
+ * Sensors, 19(10), 2372.
+ *
+ * @param weight, a M x 1 matrix containing M weights
+ * @param quaternion, a 4 x N matrix each column of which is a unit quaternion
+ *
+ * @return a 4-vector representing the weighted mean of the input quaternion set
+ *
+ */
+Eigen::VectorXd mean_quaternion(const Eigen::Ref<const Eigen::MatrixXd>& weight, const Eigen::Ref<const Eigen::MatrixXd>& quaternion);
+
+
+/**
  * Evaluate the logarithm of a multivariate Gaussian probability density function.
  *
  * @param input Input representing the argument of the function as a vector or matrix.

--- a/src/BayesFilters/include/BayesFilters/utils.h
+++ b/src/BayesFilters/include/BayesFilters/utils.h
@@ -62,6 +62,23 @@ double log_sum_exp(const Eigen::Ref<const Eigen::VectorXd>& arguments);
 
 
 /**
+ *
+ * Convert a matrix of unit quaternions (in the form (w, x, y ,z) = (w, n))
+ * to their rotation vector representation in the tangent space.
+ *
+ * Taken from
+ * Chiella, A. C., Teixeira, B. O., & Pereira, G. A. (2019).
+ * Quaternion-Based Robust Attitude Estimation Using an Adaptive Unscented Kalman Filter.
+ * Sensors, 19(10), 2372.
+ *
+ * @param quaternion, a 4 x N matrix each column of which is a unit quaternion
+ *
+ * @return a 3 x N matrix each column of which is the rotation vector associated to the input unit quaternion
+ */
+Eigen::MatrixXd quaternion_to_rotation_vector(const Eigen::Ref<const Eigen::MatrixXd>& quaternion);
+
+
+/**
  * Evaluate the logarithm of a multivariate Gaussian probability density function.
  *
  * @param input Input representing the argument of the function as a vector or matrix.

--- a/src/BayesFilters/include/BayesFilters/utils.h
+++ b/src/BayesFilters/include/BayesFilters/utils.h
@@ -116,6 +116,25 @@ Eigen::MatrixXd sum_quaternion_rotation_vector(const Eigen::Ref<const Eigen::Mat
 
 
 /**
+ *
+ * Evaluate the colwise difference between a set of unit quaternions and a unit quaternion (in the form (w, x, y, z) = (w, n))
+ * in terms of rotation vectors representing the displacements in the tangent space
+ *
+ * Taken from
+ * Chiella, A. C., Teixeira, B. O., & Pereira, G. A. (2019).
+ * Quaternion-Based Robust Attitude Estimation Using an Adaptive Unscented Kalman Filter.
+ * Sensors, 19(10), 2372.
+ *
+ * @param quaternion_left, a 4 x N matrix each column of which is a unit quaternion
+ * @param quaternion_right, a 4 x 1 matrix representing a unit quaternion
+ *
+ * @return a 3 x N matrix where the i-th column is the difference between the i-th left quaternion and the right quaternion in the tangent space
+ *
+ */
+Eigen::MatrixXd diff_quaternion(const Eigen::Ref<const Eigen::MatrixXd>& quaternion_left, const Eigen::Ref<const Eigen::MatrixXd>& quaternion_right);
+
+
+/**
  * Evaluate the logarithm of a multivariate Gaussian probability density function.
  *
  * @param input Input representing the argument of the function as a vector or matrix.

--- a/src/BayesFilters/include/BayesFilters/utils.h
+++ b/src/BayesFilters/include/BayesFilters/utils.h
@@ -97,6 +97,25 @@ Eigen::MatrixXd rotation_vector_to_quaternion(const Eigen::Ref<const Eigen::Matr
 
 
 /**
+ *
+ * Evaluate the colwise sum between a unit quaternion (in the form (w, x, y, z) = (w, n))
+ * and a set of rotation vectors (in the form (rx, ry, rz))
+ *
+ * Taken from
+ * Chiella, A. C., Teixeira, B. O., & Pereira, G. A. (2019).
+ * Quaternion-Based Robust Attitude Estimation Using an Adaptive Unscented Kalman Filter.
+ * Sensors, 19(10), 2372.
+ *
+ * @param quaternion, a 4 x 1 matrix representing a unit quaternion
+ * @param rotation_vector, a 3 x N matrix each column of which is a rotation vector
+ *
+ * @return a 4 x N matrix where the i-th column is the sum between the unit quaternion and the i-th rotation vector
+ *
+ */
+Eigen::MatrixXd sum_quaternion_rotation_vector(const Eigen::Ref<const Eigen::MatrixXd>& quaternion, const Eigen::Ref<const Eigen::MatrixXd>& rotation_vector);
+
+
+/**
  * Evaluate the logarithm of a multivariate Gaussian probability density function.
  *
  * @param input Input representing the argument of the function as a vector or matrix.

--- a/src/BayesFilters/src/utils.cpp
+++ b/src/BayesFilters/src/utils.cpp
@@ -103,3 +103,19 @@ MatrixXd bfl::utils::diff_quaternion(const Ref<const MatrixXd>& quaternion_left,
     /* Express displacements in the tangent space. */
     return quaternion_to_rotation_vector(products);
 }
+
+
+VectorXd bfl::utils::mean_quaternion(const Ref<const MatrixXd>& weight, const Ref<const MatrixXd>& quaternion)
+{
+    /* Weighted outer product of quaternions. */
+    MatrixXd outer_product_mean = Matrix4d::Zero();
+    for (std::size_t i = 0; i < weight.rows(); ++i)
+        outer_product_mean.noalias() += weight.col(0)(i) * quaternion.col(i) * quaternion.col(i).transpose();
+
+    /* Take the weighted mean as the eigenvector corresponding to the maximum eigenvalue. */
+    EigenSolver<Matrix4d> eigen_solver(outer_product_mean);
+    Matrix<std::complex<double>, 4, 1> eigenvalues(eigen_solver.eigenvalues());
+    int maximum_index;
+    eigenvalues.real().maxCoeff(&maximum_index);
+    return eigen_solver.eigenvectors().real().block(0, maximum_index, 4, 1);
+}

--- a/src/BayesFilters/src/utils.cpp
+++ b/src/BayesFilters/src/utils.cpp
@@ -60,3 +60,24 @@ MatrixXd bfl::utils::rotation_vector_to_quaternion(const Ref<const MatrixXd>& ro
 
     return quaternions;
 }
+
+
+MatrixXd bfl::utils::sum_quaternion_rotation_vector(const Ref<const MatrixXd>& quaternion, const Ref<const MatrixXd>& rotation_vector)
+{
+    /* Move rotation vectors to their quaternionic representation. */
+    MatrixXd vector_as_quaternion = rotation_vector_to_quaternion(rotation_vector);
+
+    Quaterniond q_right(quaternion.col(0)(0), quaternion.col(0)(1), quaternion.col(0)(2), quaternion.col(0)(3));
+
+    MatrixXd quaternions(4, rotation_vector.cols());
+    for (std::size_t i = 0; i < rotation_vector.cols(); ++i)
+    {
+        Quaterniond q_left(vector_as_quaternion.col(i)(0), vector_as_quaternion.col(i)(1), vector_as_quaternion.col(i)(2), vector_as_quaternion.col(i)(3));
+        Quaterniond sum = q_left * q_right;
+
+        quaternions.col(i)(0) = sum.w();
+        quaternions.col(i).tail<3>() = sum.vec();
+    }
+
+    return quaternions;
+}

--- a/src/BayesFilters/src/utils.cpp
+++ b/src/BayesFilters/src/utils.cpp
@@ -81,3 +81,25 @@ MatrixXd bfl::utils::sum_quaternion_rotation_vector(const Ref<const MatrixXd>& q
 
     return quaternions;
 }
+
+
+MatrixXd bfl::utils::diff_quaternion(const Ref<const MatrixXd>& quaternion_left, const Ref<const MatrixXd>& quaternion_right)
+{
+    MatrixXd products(4, quaternion_left.cols());
+
+    Quaterniond q_right(quaternion_right.col(0)(0), quaternion_right.col(0)(1), quaternion_right.col(0)(2), quaternion_right.col(0)(3));
+    Quaterniond q_right_conj = q_right.conjugate();
+
+    /* Products between each left quaternion and the conjugated right quaternion. */
+    for (std::size_t i = 0; i < quaternion_left.cols(); ++i)
+    {
+        Quaterniond q_left(quaternion_left.col(i)(0), quaternion_left.col(i)(1), quaternion_left.col(i)(2), quaternion_left.col(i)(3));
+        Quaterniond product = q_left * q_right_conj;
+
+        products.col(i)(0) = product.w();
+        products.col(i).tail<3>() = product.vec();
+    }
+
+    /* Express displacements in the tangent space. */
+    return quaternion_to_rotation_vector(products);
+}

--- a/src/BayesFilters/src/utils.cpp
+++ b/src/BayesFilters/src/utils.cpp
@@ -16,3 +16,25 @@ double bfl::utils::log_sum_exp(const Ref<const VectorXd>& arguments)
 
     return max + log((arguments.array() - max).exp().sum());
 }
+
+
+MatrixXd bfl::utils::quaternion_to_rotation_vector(const Ref<const MatrixXd>& quaternion)
+{
+    MatrixXd rotation_vectors(3, quaternion.cols());
+    for (std::size_t i = 0; i < quaternion.size(); ++i)
+    {
+        const double norm_n = quaternion.col(i).tail<3>().norm();
+        if (norm_n > 0)
+        {
+            const double w = quaternion.col(i)(0);
+            if (w < 0)
+                rotation_vectors.col(i) = - 2.0 * std::acos(-w) * quaternion.col(i).tail<3>() / norm_n;
+            else
+                rotation_vectors.col(i) = 2.0 * std::acos(w) * quaternion.col(i).tail<3>() / norm_n;
+        }
+        else
+            rotation_vectors.col(i) = Vector3d::Zero();
+    }
+
+    return rotation_vectors;
+}

--- a/src/BayesFilters/src/utils.cpp
+++ b/src/BayesFilters/src/utils.cpp
@@ -38,3 +38,25 @@ MatrixXd bfl::utils::quaternion_to_rotation_vector(const Ref<const MatrixXd>& qu
 
     return rotation_vectors;
 }
+
+
+MatrixXd bfl::utils::rotation_vector_to_quaternion(const Ref<const MatrixXd>& rotation_vector)
+{
+    MatrixXd quaternions(4, rotation_vector.cols());
+    for (std::size_t i = 0; i < rotation_vector.cols(); ++i)
+    {
+        const double norm_r = rotation_vector.col(i).norm();
+        if (norm_r > 0)
+        {
+            quaternions.col(i)(0) = std::cos(norm_r / 2.0);
+            quaternions.col(i).tail<3>() = std::sin(norm_r / 2.0) * rotation_vector.col(i) / norm_r;
+        }
+        else
+        {
+            quaternions.col(i)(0) = 1.0;
+            quaternions.col(i).tail<3>() = Vector3d::Zero();
+        }
+    }
+
+    return quaternions;
+}


### PR DESCRIPTION
Within this PR: implement utilities for handling operation between quaternions.

Mathematical expressions are taken from the following [paper](https://www.mdpi.com/1424-8220/19/10/2372)

```
Chiella, A. C., Teixeira, B. O., & Pereira, G. A. (2019).
Quaternion-Based Robust Attitude Estimation Using an Adaptive Unscented Kalman Filter.
Sensors, 19(10), 2372.
```

Details:
- Added method `bfl::utils::quaternion_to_rotation_vector()` that takes the logarithm of a unitary quaternion and return its imaginary part belonging to the tangent space, i.e. it is a rotation vector.
- Added method `bfl::utils::rotation_vector_to_quaternion()` that takes the exponential of rotation vector, i.e. the associated unitary quaternion.
- Added method `bfl::utils::sum_quaternion_rotation_vector` that evaluates the colwise sum between a unitary quaternion and a set of rotation vectors. The i-th sum is obtained as the quaternion product between the exponential of the i-th rotation vector and the quaternion. In other terms, this allows perturbating a quaternion by a given rotation vector and returning the result as a quaternion.
- Added method `bfl::utils::diff_quaternion` that evaluates the colwise difference between a set of quaternions and a given unitary quaternion (right operand). The i-th difference is obtained as the logarithm of the quaternion product between the i-th quaternion and the conjugated right operand, i.e it is a rotation vector. In other terms, this allows taking the relative rotation between two quaternions and returning the result as a rotation vector in the tangent space.
- Added method `bfl::utils::mean_quaternion` that evaluates the weighted mean of a set of unitary quaternions. The result is a quaternion.

> Notes related to the application of these operations in a Unscented Transform (UT) context:
>    - Difference is expressed as a rotation vector, as it is used to evaluate the empirical covariance matrix starting from the mean propagated quaternion and the other propagated sigma points. The resulting covariance matrix is then obtained starting from Euclidean vectors, as happens in the usual UTs, that belong to the tangent space to the Riemannian manifold where quaternions live. As a consequence, the columns of the covariance matrix describe the uncertainty associated to a propagated quaternionic random variable in terms of rotation vectors, i.e. perturbations that are well represented in the tangent space.
>    - Sum is expressed as a quaternion, as it is used to perturb the 0-th sigma point by "adding" the i-th weighted column of the square root covariance matrix in order to obtain the i-th sigma point, that has to be a quaternion. The implementation takes a quaternion and a rotation vector as operands since the columns of the covariance matrix are rotation vectors.


