### PR TITLE
Add support for quaternions to GaussianMixture and related

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@
 - Implemented MAP (maximum a posteriori) estimate extraction within method EstimatesExtraction::map().
 - Implemented overloaded version of EstimatesExtraction::extract() taking extra arguments (particle weights at the previous time step, likelihoods at the current step and matrix of Markov transition probabilities between previous and current states) required to expose MAP extraction utiliy to the user.
 - Implemented method GaussianMixture::resize().
+- Implemented method `GaussianMixture::augmentWithNoise()`.
 - Implemented method Gaussian::resize().
 - Implemented method ParticleSet::resize().
+- Added support for quaternions in classes `Gaussian`, `GaussianMixture` and `ParticleSet`.
 - Implemented evaluation of a multivariate Gaussian probability density function in method utils::multivariate_gaussian_density.
 - Implemented evaluation of the logarithm of a multivariate Gaussian probability density function in method utils::multivariate_gaussian_log_density.
 - Implemented evaluation of a multivariate Gaussian probability density function with UVR factorized covariance matrix in method `utils::multivariate_gaussian_density_UVR()`.
@@ -62,7 +64,7 @@
 - Reduce number of particles in test_SIS to reduce testing computation time in Debug.
 - Add testUPF_MAP testing MAP (maximum a posteriori) estimate extraction within a UPF particle filter.
 - Add `test_Gaussian_Density_UVR` testing the method `utils::multivariate_gaussian_density_UVR()`.
-- Change test_Gaussian in order to test resizing.
+- Change `test_Gaussian` in order to test resizing, noise augmentation and support for quaternions.
 - Update `test_KF`, `test_UKF`, `test_mixed_KF_UKF`, `test_mixed_UKF_KF`, `test_mixed_KF_SUKF` to account for the removed measurements freeze within `GaussianCorrection::correct()`.
 
 ## 🔖 Version 0.8.101

--- a/src/BayesFilters/include/BayesFilters/Gaussian.h
+++ b/src/BayesFilters/include/BayesFilters/Gaussian.h
@@ -26,7 +26,7 @@ public:
 
     Gaussian(const std::size_t dim_linear) noexcept;
 
-    Gaussian(const std::size_t dim_linear, const std::size_t dim_circular) noexcept;
+    Gaussian(const std::size_t dim_linear, const std::size_t dim_circular, const bool use_quaternion = false) noexcept;
 
     virtual ~Gaussian() noexcept;
 

--- a/src/BayesFilters/include/BayesFilters/GaussianMixture.h
+++ b/src/BayesFilters/include/BayesFilters/GaussianMixture.h
@@ -24,7 +24,7 @@ public:
 
     GaussianMixture(const std::size_t components, const std::size_t dim) noexcept;
 
-    GaussianMixture(const std::size_t components, const std::size_t dim_linear, const std::size_t dim_circular) noexcept;
+    GaussianMixture(const std::size_t components, const std::size_t dim_linear, const std::size_t dim_circular, const bool use_quaternion = false) noexcept;
 
     virtual ~GaussianMixture() noexcept;
 
@@ -66,6 +66,10 @@ public:
 
     std::size_t components;
 
+    bool use_quaternion;
+
+    std::size_t dim_circular_component;
+
     std::size_t dim;
 
     std::size_t dim_linear;
@@ -73,6 +77,8 @@ public:
     std::size_t dim_circular;
 
     std::size_t dim_noise;
+
+    std::size_t dim_covariance;
 
 protected:
     Eigen::MatrixXd mean_;

--- a/src/BayesFilters/include/BayesFilters/ParticleSet.h
+++ b/src/BayesFilters/include/BayesFilters/ParticleSet.h
@@ -24,7 +24,7 @@ public:
 
     ParticleSet(const std::size_t components, const std::size_t dim) noexcept;
 
-    ParticleSet(const std::size_t components, const std::size_t dim_linear, const std::size_t dim_circular) noexcept;
+    ParticleSet(const std::size_t components, const std::size_t dim_linear, const std::size_t dim_circular, const bool use_quaternion = false) noexcept;
 
     virtual ~ParticleSet() noexcept;
 

--- a/src/BayesFilters/src/Gaussian.cpp
+++ b/src/BayesFilters/src/Gaussian.cpp
@@ -13,17 +13,22 @@ using namespace bfl;
 using namespace Eigen;
 
 Gaussian::Gaussian() noexcept :
-    GaussianMixture(1, 1)
+    GaussianMixture(1, 1, 0, false)
 { }
 
 
 Gaussian::Gaussian(const std::size_t dim_linear) noexcept :
-    GaussianMixture(1, dim_linear)
+    GaussianMixture(1, dim_linear, 0, false)
 { }
 
 
-Gaussian::Gaussian(const std::size_t dim_linear, const std::size_t dim_circular) noexcept :
-    GaussianMixture(1, dim_linear, dim_circular)
+Gaussian::Gaussian
+(
+    const std::size_t dim_linear,
+    const std::size_t dim_circular,
+    const bool use_quaternion
+) noexcept :
+    GaussianMixture(1, dim_linear, dim_circular, use_quaternion)
 { }
 
 

--- a/src/BayesFilters/src/ParticleSet.cpp
+++ b/src/BayesFilters/src/ParticleSet.cpp
@@ -11,12 +11,12 @@ using namespace bfl;
 using namespace Eigen;
 
 ParticleSet::ParticleSet() noexcept :
-    ParticleSet(1, 1, 0)
+    ParticleSet(1, 1, 0, false)
 { }
 
 
 ParticleSet::ParticleSet(const std::size_t components, const std::size_t dim) noexcept:
-    ParticleSet(components, dim, 0)
+    ParticleSet(components, dim, 0, false)
 { }
 
 
@@ -24,9 +24,10 @@ ParticleSet::ParticleSet
 (
     const std::size_t components,
     const std::size_t dim_linear,
-    const std::size_t dim_circular
+    const std::size_t dim_circular,
+    const bool use_quaternion
 ) noexcept :
-    GaussianMixture(components, dim_linear, dim_circular),
+    GaussianMixture(components, dim_linear, dim_circular, use_quaternion),
     state_(dim, components)
 { }
 
@@ -37,7 +38,7 @@ ParticleSet::~ParticleSet() noexcept
 
 void ParticleSet::resize(const std::size_t components, const std::size_t dim_linear, const std::size_t dim_circular)
 {
-    std::size_t new_dim = dim_linear + dim_circular;
+    std::size_t new_dim = dim_linear + dim_circular * dim_circular_component;
 
     if ((this->dim_linear == dim_linear) && (this->dim_circular = dim_circular) && (this->components == components))
         return;
@@ -66,8 +67,8 @@ ParticleSet& ParticleSet::operator+=(const ParticleSet& rhs)
     mean_.conservativeResize(NoChange,  new_components);
     mean_.rightCols(rhs.components) = rhs.mean_;
 
-    covariance_.conservativeResize(NoChange, dim * new_components);
-    covariance_.rightCols(dim * rhs.components) = rhs.covariance_;
+    covariance_.conservativeResize(NoChange, dim_covariance * new_components);
+    covariance_.rightCols(dim_covariance * rhs.components) = rhs.covariance_;
 
     weight_.conservativeResize(new_components);
     weight_.tail(rhs.components) = rhs.weight_;

--- a/test/test_Gaussian/main.cpp
+++ b/test/test_Gaussian/main.cpp
@@ -659,5 +659,156 @@ int main()
         std::cout << "done!\n" << std::endl;
     }
 
+    std::cout << "[Test 7] Gaussian Mixture with noise augmentation (using quaternions)" << std::endl;
+    {
+        std::cout << "Constructing a Gaussian mixture..." << std::endl;
+
+        GaussianMixture mixture(2, 1, 1, true);
+
+        if (mixture.dim != 5)
+        {
+            std::cerr << "Dim is " << mixture.dim << ", should be 5" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (mixture.dim_linear != 1)
+        {
+            std::cerr << "Dim_linear is " << mixture.dim_linear << ", should be 1" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (mixture.dim_circular != 1)
+        {
+            std::cerr << "Dim_circular is " << mixture.dim_circular << ", should be 1" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (mixture.dim_circular_component != 4)
+        {
+            std::cerr << "Dim_circular_component is " << mixture.dim_circular_component << ", should be 4" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (mixture.dim_covariance != 4)
+        {
+            std::cerr << "Dim_covariance is " << mixture.dim_covariance << ", should be 4" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (mixture.dim_noise != 0)
+        {
+            std::cerr << "Dim_noise is " << mixture.dim_noise << ", should be 0" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (!mixture.use_quaternion)
+        {
+            std::cerr << "Use_quaternion is " << (mixture.use_quaternion ? "true" : "false") << ", should be true" << std::endl;
+            return EXIT_FAILURE;
+        }
+
+        std::cout << "Assign values to the Gaussian mixture..." << std::endl;
+
+        mixture.mean(0) << 1, 2, 3, 4, 5;
+
+        mixture.covariance(0) << 11, 12, 13, 14,
+                                 21, 22, 23, 24,
+                                 31, 32, 33, 34,
+                                 41, 42, 43, 44;
+
+        mixture.mean(1) << 6, 7, 8, 9, 10;
+        mixture.covariance(1) << 51, 52, 53, 54,
+                                 61, 62, 63, 64,
+                                 71, 72, 73, 74,
+                                 81, 82, 83, 84;
+
+        std::cout << "Augment gaussian with noise..." << std::endl;
+
+        Eigen:: MatrixXd noise_covariance_matrix(2, 2);
+        noise_covariance_matrix << 91, 92,
+                                   101, 102;
+
+        mixture.augmentWithNoise(noise_covariance_matrix);
+
+        if (mixture.dim != 7)
+        {
+            std::cerr << "Dim is " << mixture.dim << ", should be 7" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (mixture.dim_linear != 1)
+        {
+            std::cerr << "Dim_linear is " << mixture.dim_linear << ", should be 1" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (mixture.dim_circular != 1)
+        {
+            std::cerr << "Dim_circular is " << mixture.dim_circular << ", should be 1" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (mixture.dim_circular_component != 4)
+        {
+            std::cerr << "Dim_circular_component is " << mixture.dim_circular_component << ", should be 4" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (mixture.dim_covariance != 6)
+        {
+            std::cerr << "Dim_covariance is " << mixture.dim_covariance << ", should be 6" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (mixture.dim_noise != 2)
+        {
+            std::cerr << "Dim_noise is " << mixture.dim_noise << ", should be 2" << std::endl;
+            return EXIT_FAILURE;
+        }
+        if (!mixture.use_quaternion)
+        {
+            std::cerr << "Use_quaternion is " << (mixture.use_quaternion ? "true" : "false") << ", should be true" << std::endl;
+            return EXIT_FAILURE;
+        }
+
+        if (!(
+              /* Mean of first component. */
+              (mixture.mean(0, 0) == 1) &&
+              (mixture.mean(0, 1) == 2) &&
+              (mixture.mean(0, 2) == 3) &&
+              (mixture.mean(0, 3) == 4) &&
+              (mixture.mean(0, 4) == 5) &&
+              (mixture.mean(0, 5) == 0) &&
+              (mixture.mean(0, 6) == 0) &&
+
+              /* Mean of second component. */
+              (mixture.mean(1, 0) == 6) &&
+              (mixture.mean(1, 1) == 7) &&
+              (mixture.mean(1, 2) == 8) &&
+              (mixture.mean(1, 3) == 9) &&
+              (mixture.mean(1, 4) == 10) &&
+              (mixture.mean(1, 5) == 0) &&
+              (mixture.mean(1, 6) == 0)))
+        {
+            std::cerr << "Mean of augmented gaussian mixture is wrong, it is\n" << mixture.mean() << std::endl;
+            return EXIT_FAILURE;
+        }
+        else
+            std::cout << "Mean of augmented gaussian mixture evaluated succesfully:\n" << mixture.mean() << std::endl;
+
+        if (!(
+              /* Covariance of first component. */
+              (mixture.covariance(0, 0, 0) == 11) && (mixture.covariance(0, 0, 1) == 12) && (mixture.covariance(0, 0, 2) == 13) && (mixture.covariance(0, 0, 3) == 14) && (mixture.covariance(0, 0, 4) == 0) && (mixture.covariance(0, 0, 5) == 0) &&
+              (mixture.covariance(0, 1, 0) == 21) && (mixture.covariance(0, 1, 1) == 22) && (mixture.covariance(0, 1, 2) == 23) && (mixture.covariance(0, 1, 3) == 24) && (mixture.covariance(0, 1, 4) == 0) && (mixture.covariance(0, 1, 5) == 0) &&
+              (mixture.covariance(0, 2, 0) == 31) && (mixture.covariance(0, 2, 1) == 32) && (mixture.covariance(0, 2, 2) == 33) && (mixture.covariance(0, 2, 3) == 34) && (mixture.covariance(0, 2, 4) == 0) && (mixture.covariance(0, 2, 5) == 0) &&
+              (mixture.covariance(0, 3, 0) == 41) && (mixture.covariance(0, 3, 1) == 42) && (mixture.covariance(0, 3, 2) == 43) && (mixture.covariance(0, 3, 3) == 44) && (mixture.covariance(0, 3, 4) == 0) && (mixture.covariance(0, 3, 5) == 0) &&
+              (mixture.covariance(0, 4, 0) == 0) && (mixture.covariance(0, 4, 1) == 0) && (mixture.covariance(0, 4, 2) == 0) && (mixture.covariance(0, 4, 3) == 0) && (mixture.covariance(0, 4, 4) == 91) && (mixture.covariance(0, 4, 5) == 92) &&
+              (mixture.covariance(0, 5, 0) == 0) && (mixture.covariance(0, 5, 1) == 0) && (mixture.covariance(0, 5, 2) == 0) && (mixture.covariance(0, 5, 3) == 0) && (mixture.covariance(0, 5, 4) == 101) && (mixture.covariance(0, 5, 5) == 102) &&
+
+              /* Covariance of second component. */
+              (mixture.covariance(1, 0, 0) == 51) && (mixture.covariance(1, 0, 1) == 52) && (mixture.covariance(1, 0, 2) == 53) && (mixture.covariance(1, 0, 3) == 54) && (mixture.covariance(1, 0, 4) == 0) && (mixture.covariance(1, 0, 5) == 0) &&
+              (mixture.covariance(1, 1, 0) == 61) && (mixture.covariance(1, 1, 1) == 62) && (mixture.covariance(1, 1, 2) == 63) && (mixture.covariance(1, 1, 3) == 64) && (mixture.covariance(1, 1, 4) == 0) && (mixture.covariance(1, 1, 5) == 0) &&
+              (mixture.covariance(1, 2, 0) == 71) && (mixture.covariance(1, 2, 1) == 72) && (mixture.covariance(1, 2, 2) == 73) && (mixture.covariance(1, 2, 3) == 74) && (mixture.covariance(1, 2, 4) == 0) && (mixture.covariance(1, 2, 5) == 0) &&
+              (mixture.covariance(1, 3, 0) == 81) && (mixture.covariance(1, 3, 1) == 82) && (mixture.covariance(1, 3, 2) == 83) && (mixture.covariance(1, 3, 3) == 84) && (mixture.covariance(1, 3, 4) == 0) && (mixture.covariance(1, 3, 5) == 0) &&
+              (mixture.covariance(1, 4, 0) == 0) && (mixture.covariance(1, 4, 1) == 0) && (mixture.covariance(1, 4, 2) == 0) && (mixture.covariance(1, 4, 3) == 0) && (mixture.covariance(1, 4, 4) == 91) && (mixture.covariance(1, 4, 5) == 92) &&
+              (mixture.covariance(1, 5, 0) == 0) && (mixture.covariance(1, 5, 1) == 0) && (mixture.covariance(1, 5, 2) == 0) && (mixture.covariance(1, 5, 3) == 0) && (mixture.covariance(1, 5, 4) == 101) && (mixture.covariance(1, 5, 5) == 102)))
+        {
+            std::cerr << "Covariance of augmented gaussian is wrong, it is\n" << mixture.covariance() << std::endl;
+            return EXIT_FAILURE;
+        }
+        else
+            std::cout << "Covariance of augmented gaussian evaluated successful:\n" << mixture.covariance() << std::endl;
+        std::cout << "done!\n" << std::endl;
+    }
+
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Within this PR: 
- added support for quaternions to `GaussianMixture` and derived classes (`Gaussian` and `ParticleSet`).
- updated `test_Gaussian`
- updated `CHANGELOG.md`

#### Details
The most important change is done inside the class `GaussianMixture` where a new argument `use_quaternion` is supported in the generic constructor. By default, the constructor assumes that `use_quaternion = false`.

The interpretation is the following:
- when `use_quaternion == false` and `dim_circular != 0`, then each circular component is treated as a component in the manifold `S1`, i.e. the circle. Since `GaussianMixture`, and derived, are mainly responsible for the storage, the mean circular components are stored as vectors in `R^{dim_circular}` and the associated covariance matrices as matrices in `R^{dim_circular x dim_circular}`. This is the default behavior that the library was already implementing.
- when `use_quaternion == true` and `dim_circular != 0`, then each circular component is treated as a component in the manifold `S3` represented using a quaternion. Storage-wise, the mean associated with each quaternion is stored as a vector in `R^4`(i.e. real and imaginary part of the quaternion) and the associated covariance matrix as a matrix in `R^{3 x 3}`. Indeed, the uncertainty associated with the quaternion is best represented in the tangent space, i.e. rotation vectors, that can be treated as `R^{3}`.
