### PR TITLE
Restructure 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Added method `bfl::utils::sum_quaternion_rotation_vector()` that evaluates the colwise sum between a unitary quaternion and a set of rotation vectors. The i-th sum is obtained as the quaternion product between the exponential of the i-th rotation vector and the quaternion.
 - Added method `bfl::utils::diff_quaternion()` that evaluates the colwise difference between a set of quaternions and a given unitary quaternion (right operand). The i-th difference is obtained as the logarithm of the quaternion product between the i-th quaternion and the conjugated right operand, i.e it is a rotation vector.
 - Added method `bfl::utils::mean_quaternion()` that evaluates the weighted mean of a set of unitary quaternions.
+- utils.h is now a template header-only utility file.
 
 ##### `Filtering functions`
 - Added pure public virtual method GaussianPrediction::getStateModel() (required to properly implement GPFPrediction::getStateModel()).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@
 - `GaussianPrediction` is not a friend of `GPFPrediction` anymore.
 - `GaussianCorrection` is not a friend of `GPFCorrection` anymore.
 - Removed decorator classes. Using decorator was an easy way of extending functionalities, but at the cost of writing erroneous behavior in the filters.
+- Removed friendships from `*Prediction` and `*Correction` classes.
+- Implemented `freeze_measurments` for `*Correction` classes.
 
 ##### `Filtering algorithms`
 - `SIS::filteringStep()` performs measurements freeze before performing the actual correction. The correction is skipped if the freeze fails. The user might want to re-implement this method (or provide their own algorithm) if they need to handle the measurements freeze differently.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ##### `CMake`
 - Minor version increases since API compatibility is broken.
 
+##### `General improvements`
+- Changed any::any default pointer value to nullptr.
+
 ##### `Filtering utilities`
 - Constructor EstimatesExtraction::EstimatesExtraction() takes the state size, both linear and circular.
 - Class EstimatesExtraction does not assume that the state is a 7-vector containing cartesian position and axis/angle representation of orientation anymore.
@@ -76,7 +79,7 @@
 ##### `CMake`
  - Add CMake variable TEST_LOG_TO_FILE to disable file logs in tests.
 
-##### `General fixes`
+##### `General improvements`
  - Added missing `override` keyword.
  - Reordered data member initialization list of SIS class.
 

--- a/src/BayesFilters/CMakeLists.txt
+++ b/src/BayesFilters/CMakeLists.txt
@@ -126,7 +126,6 @@ set(${LIBRARY_TARGET_NAME}_FU_SRC
         src/Logger.cpp
         src/ParticleSet.cpp
         src/sigma_point.cpp
-        src/utils.cpp
 )
 
 set(${LIBRARY_TARGET_NAME}_SRC

--- a/src/BayesFilters/include/BayesFilters/GaussianCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/GaussianCorrection.h
@@ -29,6 +29,8 @@ public:
 
     virtual MeasurementModel& getMeasurementModel() = 0;
 
+    bool freeze_measurements();
+
     virtual std::pair<bool, Eigen::VectorXd> getLikelihood();
 
 protected:

--- a/src/BayesFilters/include/BayesFilters/PFCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/PFCorrection.h
@@ -39,6 +39,8 @@ public:
 
     virtual MeasurementModel& getMeasurementModel() = 0;
 
+    bool freeze_measurements();
+
     virtual std::pair<bool, Eigen::VectorXd> getLikelihood() = 0;
 
 protected:
@@ -48,8 +50,6 @@ protected:
 
 private:
     bool skip_ = false;
-
-    friend class PFCorrectionDecorator;
 };
 
 #endif /* PFCORRECTION_H */

--- a/src/BayesFilters/include/BayesFilters/PFPrediction.h
+++ b/src/BayesFilters/include/BayesFilters/PFPrediction.h
@@ -55,8 +55,6 @@ private:
     bool skip_state_ = false;
 
     bool skip_exogenous_ = false;
-
-    friend class PFPredictionDecorator;
 };
 
 #endif /* PFPREDICTION_H */

--- a/src/BayesFilters/include/BayesFilters/any.h
+++ b/src/BayesFilters/include/BayesFilters/any.h
@@ -11,14 +11,15 @@
  *   + https://cplusplus.github.io/LWG/lwg-active.html#2509
  *
  * Copyright Kevlin Henney, 2000, 2001, 2002. All rights reserved.
- * Copyright Claudio Fantacci, 2018. All rights reserved.
+ * Copyright Antony Polukhin, 2013-2019. All rights reserved.
+ * Copyright Claudio Fantacci, 2018-2019. All rights reserved.
  *
  * What: Variant type boost::any.
  * Who:  Contributed by Kevlin Henney,
  *       with features contributed and bugs found by Antony Polukhin, Ed Brey,
  *           Mark Rodgers, Peter Dimov and James Curran,
  *       with C++11 compiler port by Claudio Fantacci.
- * When: July 2001, April 2013 - May 2013, September 2018.
+ * When: July 2001, April 2013 - 2019.
  *
  * Distributed under the Boost Software License, Version 1.0.
  * See the following license or copy at http://www.boost.org/LICENSE_1_0.txt

--- a/src/BayesFilters/include/BayesFilters/any.h
+++ b/src/BayesFilters/include/BayesFilters/any.h
@@ -71,13 +71,16 @@ namespace any
  * of the class any object. The stored instance is called the contained object.
  * Two states are equivalent if they are either both empty or if both are not
  * empty and if the contained objects are equivalent.
- * The non-member any_cast functions provide type-safe access to the contained object.
+ * The non-member any_cast functions provide type-safe access to the contained
+ * object.
  */
 class any
 {
 public:
     /**
      * Constructs an empty object.
+     *
+     * Postconditions: this->empty().
      */
     any() noexcept :
         content(nullptr)
@@ -88,6 +91,9 @@ public:
      * Copies content of other into a new instance, so that any content is equivalent
      * in both type and value to those of other prior to the constructor call,
      * or empty if other is empty.
+     *
+     * Throws: may fail with a std::bad_alloc exception or any exceptions arising
+     *         from the copy constructor of the contained type.
      */
     any(const any& other) :
         content(other.content ? other.content->clone() : nullptr)
@@ -98,6 +104,8 @@ public:
      * Moves content of other into a new instance, so that any content is equivalent
      * in both type and value to those of other prior to the constructor call,
      * or empty if other is empty.
+     *
+     * Postconditions: other->empty()
      */
     any(any&& other) noexcept :
         content(other.content)
@@ -110,6 +118,8 @@ public:
      * Constructs an object with initial content an object of type std::decay_t<ValueType>,
      * direct-initialized from std::forward<ValueType>(value). If
      * std::is_copy_constructible<std::decay_t<ValueType>>::value is false, the program is ill-formed.
+     *
+     * Throws: std::bad_alloc or any exceptions arising from the copy constructor of the contained type.
      */
     template<typename ValueType>
     any(const ValueType& value) :
@@ -121,6 +131,8 @@ public:
      * Constructs an object with initial content an object of type std::decay_t<ValueType>,
      * direct-initialized from std::forward<ValueType>(value). If
      * std::is_copy_constructible<std::decay_t<ValueType>>::value is false, the program is ill-formed.
+     *
+     * Throws: std::bad_alloc or any exceptions arising from the copy constructor of the contained type.
      */
     template<typename ValueType>
     any(ValueType&& value, typename std::enable_if<!std::is_same<any&, ValueType>::value>::type* = nullptr, typename std::enable_if<!std::is_const<ValueType>::value>::type* = nullptr) :
@@ -129,17 +141,11 @@ public:
 
 
     /**
-     * Destruct the object.
-     */
-    ~any() noexcept
-    {
-        delete content;
-    }
-
-
-    /**
      * Assigns contents to the contained value.
      * Assigns by copying the state of rhs, as if by any(rhs).swap(*this).
+     *
+     * Throws: std::bad_alloc or any exceptions arising from the copy constructor of the contained type.
+     *         Assignment satisfies the strong guarantee of exception safety.
      *
      * @param rhs object whose contained value to assign
      */
@@ -154,6 +160,8 @@ public:
      * Assigns contents to the contained value.
      * Assigns by moving the state of rhs, as if by any(std::move(rhs)).swap(*this).
      * rhs is left in a valid but unspecified state after the assignment.
+     *
+     * Postconditions: rhs->empty()
      *
      * @param rhs object whose contained value to assign
      */
@@ -171,6 +179,9 @@ public:
      * This overload only participates in overload resolution if std::decay_t<ValueType> is not
      * the same type as any and std::is_copy_constructible_v<std::decay_t<ValueType>> is true.
      *
+     * Throws: std::bad_alloc or any exceptions arising from the move or copy constructor of the contained type.
+     *         Assignment satisfies the strong guarantee of exception safety.
+     *
      * @param rhs object whose contained value to assign
      */
     template <class ValueType>
@@ -178,6 +189,15 @@ public:
     {
         any(static_cast<ValueType&&>(rhs)).swap(*this);
         return *this;
+    }
+
+
+    /**
+     * Destruct the object.
+     */
+    ~any() noexcept
+    {
+        delete content;
     }
 
 
@@ -230,8 +250,9 @@ private:
         virtual ~placeholder()
         { }
 
-    public:
+
         virtual const std::type_info& type() const noexcept = 0;
+
 
         virtual placeholder* clone() const = 0;
 
@@ -266,14 +287,16 @@ private:
 
         ValueType held;
 
+
     private:
-        holder& operator=(const holder &);
+        /* Intentionally left unimplemented. */
+        holder& operator=(const holder&);
     };
 
 
-private:
     template<typename ValueType>
-    friend ValueType* any_cast(any*) noexcept;
+    friend ValueType* any_cast(any* operand) noexcept;
+
 
     placeholder* content;
 };
@@ -376,6 +399,7 @@ template<typename ValueType>
 inline ValueType any_cast(const any& operand)
 {
     typedef typename std::remove_reference<ValueType>::type nonref;
+
     return any_cast<const nonref&>(const_cast<any&>(operand));
 }
 
@@ -391,8 +415,7 @@ inline ValueType any_cast(const any& operand)
 template<typename ValueType>
 inline ValueType any_cast(any&& operand)
 {
-    static_assert(std::is_rvalue_reference<ValueType&&>::value || std::is_const<typename std::remove_reference<ValueType>::type>::value,
-        "any_cast shall not be used for getting nonconst references to temporary objects");
+    static_assert(std::is_rvalue_reference<ValueType&&>::value || std::is_const<typename std::remove_reference<ValueType>::type>::value, "any_cast shall not be used for getting nonconst references to temporary objects");
 
     return any_cast<ValueType>(operand);
 }

--- a/src/BayesFilters/include/BayesFilters/any.h
+++ b/src/BayesFilters/include/BayesFilters/any.h
@@ -79,7 +79,7 @@ public:
      * Constructs an empty object.
      */
     any() noexcept :
-        content(0)
+        content(nullptr)
     { }
 
 
@@ -89,7 +89,7 @@ public:
      * or empty if other is empty.
      */
     any(const any& other) :
-        content(other.content ? other.content->clone() : 0)
+        content(other.content ? other.content->clone() : nullptr)
     { }
 
 
@@ -101,7 +101,7 @@ public:
     any(any&& other) noexcept :
         content(other.content)
     {
-        other.content = 0;
+        other.content = nullptr;
     }
 
 
@@ -122,7 +122,7 @@ public:
      * std::is_copy_constructible<std::decay_t<ValueType>>::value is false, the program is ill-formed.
      */
     template<typename ValueType>
-    any(ValueType&& value, typename std::enable_if<!std::is_same<any&, ValueType>::value>::type* = 0, typename std::enable_if<!std::is_const<ValueType>::value>::type* = 0) :
+    any(ValueType&& value, typename std::enable_if<!std::is_same<any&, ValueType>::value>::type* = nullptr, typename std::enable_if<!std::is_const<ValueType>::value>::type* = nullptr) :
         content(new holder<typename std::decay<ValueType>::type>(static_cast<ValueType&&>(value)))
     { }
 
@@ -321,7 +321,7 @@ public:
 template<typename ValueType>
 ValueType* any_cast(any* operand) noexcept
 {
-    return operand && operand->type() == typeid(ValueType) ? std::addressof(static_cast<any::holder<typename std::remove_cv<ValueType>::type>*>(operand->content)->held) : 0;
+    return operand && operand->type() == typeid(ValueType) ? std::addressof(static_cast<any::holder<typename std::remove_cv<ValueType>::type>*>(operand->content)->held) : nullptr;
 }
 
 

--- a/src/BayesFilters/include/BayesFilters/utils.h
+++ b/src/BayesFilters/include/BayesFilters/utils.h
@@ -18,6 +18,7 @@
 #include <Eigen/Dense>
 
 #include <chrono>
+#include <cmath>
 #include <memory>
 
 namespace bfl
@@ -56,9 +57,22 @@ std::unique_ptr<T> make_unique(Args&& ...args)
 
 
 /**
- * Return the logarithm of the sum of exponentials.
+ * Return the element-wise logarithm of the sum of exponentials of the input data.
+ *
+ * To learn more about logsumexp, read https://en.wikipedia.org/wiki/LogSumExp.
+ *
+ * @param data Input numbers as a vector or a matrix.
+ *
+ * @return The element-wise logsumexp of the input data.
  */
-double log_sum_exp(const Eigen::Ref<const Eigen::VectorXd>& arguments);
+template<typename Derived>
+double log_sum_exp(const Eigen::MatrixBase<Derived>& data)
+{
+    double max = static_cast<double>(data.maxCoeff());
+
+    return max + std::log(static_cast<double>((data.array() - max).exp().sum()));
+}
+
 
 
 /**

--- a/src/BayesFilters/src/EstimatesExtraction.cpp
+++ b/src/BayesFilters/src/EstimatesExtraction.cpp
@@ -243,7 +243,7 @@ VectorXd EstimatesExtraction::map
      * Saha, S., Boers, Y., Driessen, H., Mandal, P. K., Bagchi, A. (2009),
      * 'Particle Based MAP State Estimation: A Comparison.',
      * 12th International Conference on Information Fusion,
-     * Seattle, WA, USA, July 6-9, 2009. 
+     * Seattle, WA, USA, July 6-9, 2009.
      *
      * The equation is rewritten in order to work in the log space.
      */
@@ -254,7 +254,7 @@ VectorXd EstimatesExtraction::map
 
     double eps = std::numeric_limits<double>::min();
     for (std::size_t i = 0; i < values.size(); i++)
-        values(i) = log(likelihoods(i) + eps) + utils::log_sum_exp((transition_probabilities.row(i).transpose().array() + eps).log() + previous_weights.array());
+        values(i) = std::log(likelihoods(i) + eps) + utils::log_sum_exp(((transition_probabilities.row(i).transpose().array() + eps).log() + previous_weights.array()).matrix());
 
     values.maxCoeff(&map_index);
 
@@ -285,7 +285,7 @@ VectorXd EstimatesExtraction::simpleAverage
 
     MatrixXd history = hist_buffer_.getHistoryBuffer();
     if (sm_weights_.size() != history.cols())
-        sm_weights_ = VectorXd::Constant(history.cols(), -log(history.cols()));
+        sm_weights_ = VectorXd::Constant(history.cols(), -std::log(history.cols()));
 
 
     return mean(history, sm_weights_);
@@ -318,7 +318,7 @@ VectorXd EstimatesExtraction::weightedAverage
     {
         wm_weights_.resize(history.cols());
         for (unsigned int i = 0; i < history.cols(); ++i)
-            wm_weights_(i) = log(history.cols() - i);
+            wm_weights_(i) = std::log(history.cols() - i);
 
         wm_weights_.array() -= utils::log_sum_exp(wm_weights_);
     }

--- a/src/BayesFilters/src/GPFCorrection.cpp
+++ b/src/BayesFilters/src/GPFCorrection.cpp
@@ -108,11 +108,12 @@ void GPFCorrection::correctStep(const bfl::ParticleSet& pred_particles, bfl::Par
     VectorXd transition_probability = state_model_->getTransitionProbability(pred_particles.state(), corr_particles.state());
 
     /* Update weights in the log space.
-     w_{k} = w_{k-1} + log(likelihood) + log(transition_probability) - log(proposal_distribution) */
+     * w_{k} = w_{k-1} + log(likelihood) + log(transition_probability) - log(proposal_distribution)
+     */
     double eps = std::numeric_limits<double>::min();
     for (std::size_t i = 0; i < pred_particles.components; i++)
     {
-        corr_particles.weight(i) = pred_particles.weight(i) + log(likelihood_(i) + eps) + log(transition_probability(i) + eps) - log(evaluateProposal(corr_particles.state(i), corr_particles.mean(i), corr_particles.covariance(i)) + eps);
+        corr_particles.weight(i) = pred_particles.weight(i) + std::log(likelihood_(i) + eps) + std::log(transition_probability(i) + eps) - std::log(evaluateProposal(corr_particles.state(i), corr_particles.mean(i), corr_particles.covariance(i)) + eps);
     }
 }
 

--- a/src/BayesFilters/src/GaussianCorrection.cpp
+++ b/src/BayesFilters/src/GaussianCorrection.cpp
@@ -24,15 +24,21 @@ void GaussianCorrection::correct(const GaussianMixture& pred_state, GaussianMixt
 }
 
 
-std::pair<bool, VectorXd> GaussianCorrection::getLikelihood()
-{
-    return std::make_pair(false, VectorXd::Zero(1));
-}
-
-
 bool GaussianCorrection::skip(const bool status)
 {
     skip_ = status;
 
     return true;
+}
+
+
+bool GaussianCorrection::freeze_measurements()
+{
+    return getMeasurementModel().freeze();
+}
+
+
+std::pair<bool, VectorXd> GaussianCorrection::getLikelihood()
+{
+    throw std::runtime_error("ERROR::GAUSSIANCORRECTION::GETLIKELIHOOD\nERROR:\n\tCall to unimplemented base class method.");
 }

--- a/src/BayesFilters/src/InitSurveillanceAreaGrid.cpp
+++ b/src/BayesFilters/src/InitSurveillanceAreaGrid.cpp
@@ -57,7 +57,7 @@ bool InitSurveillanceAreaGrid::initialize(ParticleSet& particles)
                                                             static_cast<double>((delta_surv_y / (num_particle_y_ - 1)) * j + surv_y_inf_),
                                                                                                                                         0;
 
-    particles.weight().setConstant(-log(num_particle));
+    particles.weight().setConstant(-std::log(num_particle));
 
     return true;
 }

--- a/src/BayesFilters/src/LTIStateModel.cpp
+++ b/src/BayesFilters/src/LTIStateModel.cpp
@@ -14,7 +14,8 @@ using namespace Eigen;
 
 
 LTIStateModel::LTIStateModel(const Ref<const MatrixXd>& transition_matrix, const Ref<const MatrixXd>& noise_covariance_matrix) :
-    F_(transition_matrix), Q_(noise_covariance_matrix)
+    F_(transition_matrix),
+    Q_(noise_covariance_matrix)
 {
     if ((F_.rows() == 0) || (F_.cols() == 0))
         throw std::runtime_error("ERROR::LTISTATEMODEL::CTOR\nERROR:\n\tState transition matrix dimensions cannot be 0.");

--- a/src/BayesFilters/src/PFCorrection.cpp
+++ b/src/BayesFilters/src/PFCorrection.cpp
@@ -30,3 +30,9 @@ bool PFCorrection::skip(const bool status)
 
     return true;
 }
+
+
+bool PFCorrection::freeze_measurements()
+{
+    return getMeasurementModel().freeze();
+}

--- a/src/BayesFilters/src/Resampling.cpp
+++ b/src/BayesFilters/src/Resampling.cpp
@@ -14,22 +14,27 @@ using namespace Eigen;
 
 
 Resampling::Resampling(unsigned int seed) noexcept :
-    generator_(std::mt19937_64(seed)) { }
+    generator_(std::mt19937_64(seed))
+{ }
 
 
 Resampling::Resampling() noexcept :
-    Resampling(1) { }
+    Resampling(1)
+{ }
 
 
-Resampling::~Resampling() noexcept { }
+Resampling::~Resampling() noexcept
+{ }
 
 
 Resampling::Resampling(const Resampling& resampling) noexcept :
-    generator_(resampling.generator_) { }
+    generator_(resampling.generator_)
+{ }
 
 
 Resampling::Resampling(Resampling&& resampling) noexcept :
-    generator_(std::move(resampling.generator_)) { }
+    generator_(std::move(resampling.generator_))
+{ }
 
 
 Resampling& Resampling::operator=(const Resampling& resampling)
@@ -81,7 +86,7 @@ void Resampling::resample(const ParticleSet& cor_particles, ParticleSet& res_par
         res_particles.state(j) = cor_particles.state(idx_csw);
         res_particles.mean(j) = cor_particles.mean(idx_csw);
         res_particles.covariance(j) = cor_particles.covariance(idx_csw);
-        res_particles.weight(j) = -log(num_particles);
+        res_particles.weight(j) = -std::log(num_particles);
         res_parents(j) = idx_csw;
     }
 }

--- a/src/BayesFilters/src/ResamplingWithPrior.cpp
+++ b/src/BayesFilters/src/ResamplingWithPrior.cpp
@@ -19,18 +19,21 @@ using namespace Eigen;
 ResamplingWithPrior::ResamplingWithPrior(std::unique_ptr<bfl::ParticleSetInitialization> init_model, const double prior_ratio, const unsigned int seed) noexcept :
     Resampling(seed),
     init_model_(std::move(init_model)),
-    prior_ratio_(prior_ratio) { }
+    prior_ratio_(prior_ratio)
+{ }
 
 
 ResamplingWithPrior::ResamplingWithPrior(std::unique_ptr<ParticleSetInitialization> init_model, const double prior_ratio) noexcept :
     Resampling(1),
     init_model_(std::move(init_model)),
-    prior_ratio_(prior_ratio)  { }
+    prior_ratio_(prior_ratio)
+{ }
 
 
 ResamplingWithPrior::ResamplingWithPrior(std::unique_ptr<ParticleSetInitialization> init_model) noexcept :
     Resampling(1),
-    init_model_(std::move(init_model)) { }
+    init_model_(std::move(init_model))
+{ }
 
 
 ResamplingWithPrior::ResamplingWithPrior(ResamplingWithPrior&& resampling) noexcept :
@@ -42,7 +45,8 @@ ResamplingWithPrior::ResamplingWithPrior(ResamplingWithPrior&& resampling) noexc
 }
 
 
-ResamplingWithPrior::~ResamplingWithPrior() noexcept { }
+ResamplingWithPrior::~ResamplingWithPrior() noexcept
+{ }
 
 
 ResamplingWithPrior& ResamplingWithPrior::operator=(ResamplingWithPrior&& resampling) noexcept
@@ -97,7 +101,7 @@ void ResamplingWithPrior::resample(const ParticleSet& cor_particles, ParticleSet
     res_particles = std::move(res_particles_left + res_particles_right);
 
     /* Reset weights.*/
-    res_particles.weight().setConstant(-log(cor_particles.state().cols()));
+    res_particles.weight().setConstant(-std::log(cor_particles.state().cols()));
 
     /* Since num_prior_particles were created from scratch,
        they do not have a parent. */

--- a/src/BayesFilters/src/SIS.cpp
+++ b/src/BayesFilters/src/SIS.cpp
@@ -89,7 +89,7 @@ void SIS::filteringStep()
     if (getFilteringStep() != 0)
         prediction_->predict(cor_particle_, pred_particle_);
 
-    if (correction_->getMeasurementModel().freeze())
+    if (correction_->freeze_measurements())
     {
         correction_->correct(pred_particle_, cor_particle_);
 

--- a/test/test_KF/main.cpp
+++ b/test/test_KF/main.cpp
@@ -57,7 +57,8 @@ protected:
     void filteringStep() override
     {
         prediction_->predict(corrected_state_, predicted_state_);
-        if (correction_->getMeasurementModel().freeze())
+
+        if (correction_->freeze_measurements())
             correction_->correct(predicted_state_, corrected_state_);
         else
             corrected_state_ = predicted_state_;

--- a/test/test_UKF/main.cpp
+++ b/test/test_UKF/main.cpp
@@ -58,7 +58,8 @@ protected:
     void filteringStep() override
     {
         prediction_->predict(corrected_state_, predicted_state_);
-        if (correction_->getMeasurementModel().freeze())
+
+        if (correction_->freeze_measurements())
             correction_->correct(predicted_state_, corrected_state_);
         else
             corrected_state_ = predicted_state_;

--- a/test/test_mixed_KF_SUKF/main.cpp
+++ b/test/test_mixed_KF_SUKF/main.cpp
@@ -58,7 +58,8 @@ protected:
     void filteringStep() override
     {
         prediction_->predict(corrected_state_, predicted_state_);
-        if (correction_->getMeasurementModel().freeze())
+
+        if (correction_->freeze_measurements())
             correction_->correct(predicted_state_, corrected_state_);
         else
             corrected_state_ = predicted_state_;

--- a/test/test_mixed_KF_UKF/main.cpp
+++ b/test/test_mixed_KF_UKF/main.cpp
@@ -58,7 +58,8 @@ protected:
     void filteringStep() override
     {
         prediction_->predict(corrected_state_, predicted_state_);
-        if (correction_->getMeasurementModel().freeze())
+
+        if (correction_->freeze_measurements())
             correction_->correct(predicted_state_, corrected_state_);
         else
             corrected_state_ = predicted_state_;

--- a/test/test_mixed_UKF_KF/main.cpp
+++ b/test/test_mixed_UKF_KF/main.cpp
@@ -58,7 +58,8 @@ protected:
     void filteringStep() override
     {
         prediction_->predict(corrected_state_, predicted_state_);
-        if (correction_->getMeasurementModel().freeze())
+
+        if (correction_->freeze_measurements())
             correction_->correct(predicted_state_, corrected_state_);
         else
             corrected_state_ = predicted_state_;


### PR DESCRIPTION

This PR is the first of a series of PRs where I try to combine some old but important commits we left in `claudiofantacci/bayes-filters-lib` and `xenvre/bayes-filters-lib`.

I will try to contain the number of commits per PR for ease of reviewing.

In this PR:
- `any::any` now defaults to `nullptr`
-  `utils.h` is now a template header-only utility file
   -  `utils::log_sum_exp` is now a template function accepting `const Eigen::MatrixBase<Derived>&`
- Remove friendship from classes `PFPrediction` and `PFCorrection`
- Implement `freeze_measurements()` method for classes `PFCorrection` and `GaussianCorrection`
- Fix license in `any.h`
- General code cleanup
  - Indentation improvement
  - Fix missing `std::` namespace for `std::log`
- Update tests accordingly
- Update `CHANGELOG.md`

Fixes #26

Fixes #45

Fixes #51
