### PR TITLE
Restructure 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - Implemented `freeze_measurments` for `*Correction` classes.
 - Made `skip`-related variable value in `*Prediction` classes coherent with assigned values.
 - Removed setters from `*Prediction` and derived classes. All the required data to create an object are passed to the constructor.
+- Removed setters from `*Correction` and derived classes. All the required data to create an object are passed to the constructor.
 
 ##### `Filtering algorithms`
 - `SIS::filteringStep()` performs measurements freeze before performing the actual correction. The correction is skipped if the freeze fails. The user might want to re-implement this method (or provide their own algorithm) if they need to handle the measurements freeze differently.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - Removed friendships from `*Prediction` and `*Correction` classes.
 - Implemented `freeze_measurments` for `*Correction` classes.
 - Made `skip`-related variable value in `*Prediction` classes coherent with assigned values.
+- Removed setters from `*Prediction` and derived classes. All the required data to create an object are passed to the constructor.
 
 ##### `Filtering algorithms`
 - `SIS::filteringStep()` performs measurements freeze before performing the actual correction. The correction is skipped if the freeze fails. The user might want to re-implement this method (or provide their own algorithm) if they need to handle the measurements freeze differently.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ##### `CMake`
 - Minor version increases since API compatibility is broken.
 
+##### `Bugfix`
+- Fixed missing self-assignment check in move assignment operators.
+
 ##### `General improvements`
 - Changed any::any default pointer value to nullptr.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,10 +63,10 @@
 - Removed decorator classes. Using decorator was an easy way of extending functionalities, but at the cost of writing erroneous behavior in the filters.
 - Removed friendships from `*Prediction` and `*Correction` classes.
 - Implemented `freeze_measurments` for `*Correction` classes.
+- Made `skip`-related variable value in `*Prediction` classes coherent with assigned values.
 
 ##### `Filtering algorithms`
 - `SIS::filteringStep()` performs measurements freeze before performing the actual correction. The correction is skipped if the freeze fails. The user might want to re-implement this method (or provide their own algorithm) if they need to handle the measurements freeze differently.
-
 
 ##### `Test`
 - Mean extraction is performed using EstimatesExtraction utilities in test_UPF.

--- a/src/BayesFilters/CMakeLists.txt
+++ b/src/BayesFilters/CMakeLists.txt
@@ -84,7 +84,6 @@ set(${LIBRARY_TARGET_NAME}_FA_SRC
 )
 
 set(${LIBRARY_TARGET_NAME}_FF_SRC
-        src/AdditiveMeasurementModel.cpp
         src/AdditiveStateModel.cpp
         src/Agent.cpp
         src/BootstrapCorrection.cpp

--- a/src/BayesFilters/include/BayesFilters/AdditiveMeasurementModel.h
+++ b/src/BayesFilters/include/BayesFilters/AdditiveMeasurementModel.h
@@ -18,7 +18,7 @@ namespace bfl {
 class bfl::AdditiveMeasurementModel : public bfl::MeasurementModel
 {
 public:
-    virtual ~AdditiveMeasurementModel() noexcept;
+    virtual ~AdditiveMeasurementModel() noexcept = default;
 };
 
 #endif /* ADDITIVEMEASUREMENTMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/AdditiveStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/AdditiveStateModel.h
@@ -20,7 +20,7 @@ namespace bfl {
 class bfl::AdditiveStateModel : public bfl::StateModel
 {
 public:
-    virtual ~AdditiveStateModel() noexcept { };
+    virtual ~AdditiveStateModel() noexcept = default;
 
     virtual void motion(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> mot_states) override;
 };

--- a/src/BayesFilters/include/BayesFilters/Agent.h
+++ b/src/BayesFilters/include/BayesFilters/Agent.h
@@ -23,7 +23,7 @@ namespace bfl {
 class bfl::Agent
 {
 public:
-    virtual ~Agent() noexcept;
+    virtual ~Agent() noexcept = default;
 
     virtual bool bufferData() = 0;
 

--- a/src/BayesFilters/include/BayesFilters/BootstrapCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/BootstrapCorrection.h
@@ -22,25 +22,33 @@ namespace bfl {
 class bfl::BootstrapCorrection : public PFCorrection
 {
 public:
+    BootstrapCorrection(std::unique_ptr<MeasurementModel> measurement_model, std::unique_ptr<LikelihoodModel> likelihood_model) noexcept;
+
+    BootstrapCorrection(const BootstrapCorrection& correction) noexcept = delete;
+
+    BootstrapCorrection& operator=(const BootstrapCorrection& correction) noexcept = delete;
+
+    BootstrapCorrection(BootstrapCorrection&& correction) noexcept;
+
+    BootstrapCorrection& operator=(BootstrapCorrection&& correction) noexcept;
+
     virtual ~BootstrapCorrection() noexcept = default;
 
-    void setLikelihoodModel(std::unique_ptr<LikelihoodModel> likelihood_model) override;
+    MeasurementModel& getMeasurementModel() noexcept override;
 
-    void setMeasurementModel(std::unique_ptr<MeasurementModel> measurement_model) override;
-
-    LikelihoodModel& getLikelihoodModel() override;
-
-    MeasurementModel& getMeasurementModel() override;
+    LikelihoodModel& getLikelihoodModel() noexcept override;
 
     std::pair<bool, Eigen::VectorXd> getLikelihood() override;
 
 
 protected:
-    std::unique_ptr<LikelihoodModel> likelihood_model_;
+    void correctStep(const ParticleSet& pred_particles, ParticleSet& cor_particles) override;
 
+
+private:
     std::unique_ptr<MeasurementModel> measurement_model_;
 
-    void correctStep(const ParticleSet& pred_particles, ParticleSet& cor_particles) override;
+    std::unique_ptr<LikelihoodModel> likelihood_model_;
 
     bool valid_likelihood_ = false;
 

--- a/src/BayesFilters/include/BayesFilters/BootstrapCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/BootstrapCorrection.h
@@ -34,6 +34,7 @@ public:
 
     std::pair<bool, Eigen::VectorXd> getLikelihood() override;
 
+
 protected:
     std::unique_ptr<LikelihoodModel> likelihood_model_;
 

--- a/src/BayesFilters/include/BayesFilters/BootstrapCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/BootstrapCorrection.h
@@ -22,9 +22,7 @@ namespace bfl {
 class bfl::BootstrapCorrection : public PFCorrection
 {
 public:
-    BootstrapCorrection() noexcept;
-
-    virtual ~BootstrapCorrection() noexcept;
+    virtual ~BootstrapCorrection() noexcept = default;
 
     void setLikelihoodModel(std::unique_ptr<LikelihoodModel> likelihood_model) override;
 

--- a/src/BayesFilters/include/BayesFilters/DrawParticles.h
+++ b/src/BayesFilters/include/BayesFilters/DrawParticles.h
@@ -26,7 +26,7 @@ public:
 
     DrawParticles(DrawParticles&& draw_particles) noexcept;
 
-    virtual ~DrawParticles() noexcept;
+    virtual ~DrawParticles() noexcept = default;
 
     virtual StateModel& getStateModel() override;
 

--- a/src/BayesFilters/include/BayesFilters/DrawParticles.h
+++ b/src/BayesFilters/include/BayesFilters/DrawParticles.h
@@ -11,9 +11,6 @@
 #include <BayesFilters/ParticleSet.h>
 #include <BayesFilters/PFPrediction.h>
 
-#include <random>
-#include <memory>
-
 namespace bfl {
     class DrawParticles;
 }
@@ -22,21 +19,29 @@ namespace bfl {
 class bfl::DrawParticles : public PFPrediction
 {
 public:
-    DrawParticles() noexcept;
+    DrawParticles(std::unique_ptr<StateModel> state_model) noexcept;
 
-    DrawParticles(DrawParticles&& draw_particles) noexcept;
+    DrawParticles(std::unique_ptr<StateModel> state_model, std::unique_ptr<ExogenousModel> exogenous_model) noexcept;
+
+    DrawParticles(const DrawParticles& prediction) noexcept = delete;
+
+    DrawParticles& operator=(const DrawParticles& prediction) noexcept = delete;
+
+    DrawParticles(DrawParticles&& prediction) noexcept;
+
+    DrawParticles& operator=(DrawParticles&& prediction) noexcept;
 
     virtual ~DrawParticles() noexcept = default;
 
-    virtual StateModel& getStateModel() override;
-
-    virtual void setStateModel(std::unique_ptr<StateModel> state_model) override;
+    StateModel& getStateModel() noexcept override;
 
 
 protected:
     void predictStep(const ParticleSet& prev_particles, ParticleSet& pred_particles) override;
 
     std::unique_ptr<StateModel> state_model_;
+
+    std::unique_ptr<ExogenousModel> exogenous_model_;
 };
 
 #endif /* DRAWPARTICLES_H */

--- a/src/BayesFilters/include/BayesFilters/DrawParticles.h
+++ b/src/BayesFilters/include/BayesFilters/DrawParticles.h
@@ -19,7 +19,7 @@ namespace bfl {
 }
 
 
-class bfl::DrawParticles: public PFPrediction
+class bfl::DrawParticles : public PFPrediction
 {
 public:
     DrawParticles() noexcept;
@@ -31,6 +31,7 @@ public:
     virtual StateModel& getStateModel() override;
 
     virtual void setStateModel(std::unique_ptr<StateModel> state_model) override;
+
 
 protected:
     void predictStep(const ParticleSet& prev_particles, ParticleSet& pred_particles) override;

--- a/src/BayesFilters/include/BayesFilters/EstimatesExtraction.h
+++ b/src/BayesFilters/include/BayesFilters/EstimatesExtraction.h
@@ -31,7 +31,7 @@ public:
 
     EstimatesExtraction& operator=(EstimatesExtraction&& estimate_extraction) noexcept;
 
-    ~EstimatesExtraction() noexcept { };
+    ~EstimatesExtraction() noexcept =default;
 
 
     enum class ExtractionMethod

--- a/src/BayesFilters/include/BayesFilters/EstimatesExtraction.h
+++ b/src/BayesFilters/include/BayesFilters/EstimatesExtraction.h
@@ -33,23 +33,12 @@ public:
 
     ~EstimatesExtraction() noexcept =default;
 
-
     enum class ExtractionMethod
     {
-        mean,
-        smean,
-        wmean,
-        emean,
-        mode,
-        smode,
-        wmode,
-        emode,
-        map,
-        smap,
-        wmap,
-        emap
+        mean, smean, wmean, emean,
+        mode, smode, wmode, emode,
+        map, smap, wmap, emap
     };
-
 
     bool setMethod(const ExtractionMethod& extraction_method);
 
@@ -61,8 +50,8 @@ public:
 
     bool clear();
 
-
     std::vector<std::string> getInfo() const;
+
 
 protected:
     ExtractionMethod extraction_method_ = ExtractionMethod::emode;
@@ -70,9 +59,10 @@ protected:
     HistoryBuffer hist_buffer_;
 
     Eigen::VectorXd sm_weights_;
-    Eigen::VectorXd wm_weights_;
-    Eigen::VectorXd em_weights_;
 
+    Eigen::VectorXd wm_weights_;
+
+    Eigen::VectorXd em_weights_;
 
     enum class Statistics
     {

--- a/src/BayesFilters/include/BayesFilters/ExogenousModel.h
+++ b/src/BayesFilters/include/BayesFilters/ExogenousModel.h
@@ -18,7 +18,7 @@ namespace bfl {
 class bfl::ExogenousModel
 {
 public:
-    virtual ~ExogenousModel() noexcept { };
+    virtual ~ExogenousModel() noexcept = default;
 
     virtual void propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> prop_states) = 0;
 

--- a/src/BayesFilters/include/BayesFilters/FilteringAlgorithm.h
+++ b/src/BayesFilters/include/BayesFilters/FilteringAlgorithm.h
@@ -19,7 +19,9 @@
 
 namespace bfl {
     class FilteringAlgorithm;
-    typedef typename std::unordered_map<std::string, double>      FilteringParamtersD;
+
+    typedef typename std::unordered_map<std::string, double> FilteringParamtersD;
+
     typedef typename std::unordered_map<std::string, std::string> FilteringParamtersS;
 }
 
@@ -47,12 +49,14 @@ public:
 
     virtual bool skip(const std::string& what_step, const bool status) = 0;
 
+
 protected:
     virtual bool initialization() = 0;
 
     virtual void filteringStep() = 0;
 
     virtual bool runCondition() = 0;
+
 
 private:
     unsigned int filtering_step_ = 0;

--- a/src/BayesFilters/include/BayesFilters/FilteringAlgorithm.h
+++ b/src/BayesFilters/include/BayesFilters/FilteringAlgorithm.h
@@ -27,7 +27,7 @@ namespace bfl {
 class bfl::FilteringAlgorithm : public Logger
 {
 public:
-    virtual ~FilteringAlgorithm() noexcept { };
+    virtual ~FilteringAlgorithm() noexcept = default;
 
     bool boot();
 

--- a/src/BayesFilters/include/BayesFilters/GPFCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/GPFCorrection.h
@@ -33,7 +33,7 @@ public:
 
     GPFCorrection(GPFCorrection&& gpf_correction) noexcept;
 
-    virtual ~GPFCorrection() noexcept { };
+    virtual ~GPFCorrection() noexcept = default;
 
     void setLikelihoodModel(std::unique_ptr<LikelihoodModel> likelihood_model) override;
 

--- a/src/BayesFilters/include/BayesFilters/GPFCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/GPFCorrection.h
@@ -27,21 +27,23 @@ namespace bfl {
 class bfl::GPFCorrection : public PFCorrection
 {
 public:
-    GPFCorrection(std::unique_ptr<GaussianCorrection> gaussian_correction, std::unique_ptr<LikelihoodModel> likelihood_model, std::unique_ptr<StateModel> state_model) noexcept;
+    GPFCorrection(std::unique_ptr<LikelihoodModel> likelihood_model, std::unique_ptr<GaussianCorrection> gaussian_correction, std::unique_ptr<StateModel> state_model) noexcept;
 
-    GPFCorrection(std::unique_ptr<GaussianCorrection> gaussian_correction, std::unique_ptr<LikelihoodModel> likelihood_model, std::unique_ptr<StateModel> state_model, unsigned int seed) noexcept;
+    GPFCorrection(std::unique_ptr<LikelihoodModel> likelihood_model, std::unique_ptr<GaussianCorrection> gaussian_correction, std::unique_ptr<StateModel> state_model, unsigned int seed) noexcept;
 
-    GPFCorrection(GPFCorrection&& gpf_correction) noexcept;
+    GPFCorrection(const GPFCorrection& correction) noexcept = delete;
+
+    GPFCorrection& operator=(const GPFCorrection& correction) noexcept = delete;
+
+    GPFCorrection(GPFCorrection&& correction) noexcept;
+
+    GPFCorrection& operator=(GPFCorrection&& correction) noexcept;
 
     virtual ~GPFCorrection() noexcept = default;
 
-    void setLikelihoodModel(std::unique_ptr<LikelihoodModel> likelihood_model) override;
+    MeasurementModel& getMeasurementModel() noexcept override;
 
-    void setMeasurementModel(std::unique_ptr<MeasurementModel> measurement_model) override;
-
-    MeasurementModel& getMeasurementModel() override;
-
-    LikelihoodModel& getLikelihoodModel() override;
+    LikelihoodModel& getLikelihoodModel() noexcept override;
 
     std::pair<bool, Eigen::VectorXd> getLikelihood() override;
 
@@ -53,9 +55,16 @@ protected:
 
     double evaluateProposal(const Eigen::VectorXd& state, const Eigen::VectorXd& mean, const Eigen::MatrixXd& covariance);
 
-    std::unique_ptr<GaussianCorrection> gaussian_correction_;
+    /**
+     * Random number generator function from a Normal distribution.
+     * A call to `gaussian_random_sample_()` returns a double-precision floating-point random number.
+     */
+    std::function<double()> gaussian_random_sample_;
 
+private:
     std::unique_ptr<LikelihoodModel> likelihood_model_;
+
+    std::unique_ptr<GaussianCorrection> gaussian_correction_;
 
     /**
      * The state model is required to evaluate the Markov transition probability
@@ -66,12 +75,6 @@ protected:
     std::mt19937_64 generator_;
 
     std::normal_distribution<double> distribution_;
-
-    /**
-     * Random number generator function from a Normal distribution.
-     * A call to `gaussian_random_sample_()` returns a double-precision floating-point random number.
-     */
-    std::function<double()> gaussian_random_sample_;
 
     bool valid_likelihood_;
 

--- a/src/BayesFilters/include/BayesFilters/GPFCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/GPFCorrection.h
@@ -45,6 +45,7 @@ public:
 
     std::pair<bool, Eigen::VectorXd> getLikelihood() override;
 
+
 protected:
     void correctStep(const ParticleSet& pred_particles, ParticleSet& corr_particles) override;
 

--- a/src/BayesFilters/include/BayesFilters/GPFPrediction.h
+++ b/src/BayesFilters/include/BayesFilters/GPFPrediction.h
@@ -24,15 +24,19 @@ namespace bfl {
 class bfl::GPFPrediction : public PFPrediction
 {
 public:
-    GPFPrediction(std::unique_ptr<GaussianPrediction> gauss_pred) noexcept;
+    GPFPrediction(std::unique_ptr<GaussianPrediction> gauss_prediction) noexcept;
 
-    GPFPrediction(GPFPrediction&& gpf_prediction) noexcept;
+    GPFPrediction(const GPFPrediction& prediction) noexcept = delete;
+
+    GPFPrediction& operator=(const GPFPrediction& prediction) noexcept = delete;
+
+    GPFPrediction(GPFPrediction&& prediction) noexcept;
+
+    GPFPrediction& operator=(GPFPrediction&& prediction) noexcept;
 
     virtual ~GPFPrediction() noexcept = default;
 
-    void setStateModel(std::unique_ptr<StateModel> state_model) override;
-
-    StateModel& getStateModel() override;
+    StateModel& getStateModel() noexcept override;
 
 
 protected:

--- a/src/BayesFilters/include/BayesFilters/GPFPrediction.h
+++ b/src/BayesFilters/include/BayesFilters/GPFPrediction.h
@@ -28,7 +28,7 @@ public:
 
     GPFPrediction(GPFPrediction&& gpf_prediction) noexcept;
 
-    virtual ~GPFPrediction() noexcept { };
+    virtual ~GPFPrediction() noexcept = default;
 
     void setStateModel(std::unique_ptr<StateModel> state_model) override;
 

--- a/src/BayesFilters/include/BayesFilters/GPFPrediction.h
+++ b/src/BayesFilters/include/BayesFilters/GPFPrediction.h
@@ -34,6 +34,7 @@ public:
 
     StateModel& getStateModel() override;
 
+
 protected:
     void predictStep(const ParticleSet& previous_particles, ParticleSet& predicted_particles) override;
 

--- a/src/BayesFilters/include/BayesFilters/Gaussian.h
+++ b/src/BayesFilters/include/BayesFilters/Gaussian.h
@@ -28,7 +28,7 @@ public:
 
     Gaussian(const std::size_t dim_linear, const std::size_t dim_circular, const bool use_quaternion = false) noexcept;
 
-    virtual ~Gaussian() noexcept;
+    virtual ~Gaussian() noexcept = default;
 
     void resize(const std::size_t dim_linear, const std::size_t dim_circular = 0);
 

--- a/src/BayesFilters/include/BayesFilters/GaussianCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/GaussianCorrection.h
@@ -35,6 +35,16 @@ public:
 
 
 protected:
+    GaussianCorrection() noexcept = default;
+
+    GaussianCorrection(const GaussianCorrection& correction) noexcept = delete;
+
+    GaussianCorrection& operator=(const GaussianCorrection& correction) noexcept = delete;
+
+    GaussianCorrection(GaussianCorrection&& correction) noexcept = default;
+
+    GaussianCorrection& operator=(GaussianCorrection&& correction) noexcept = default;
+
     virtual void correctStep(const GaussianMixture& pred_state, GaussianMixture& corr_state) = 0;
 
 

--- a/src/BayesFilters/include/BayesFilters/GaussianCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/GaussianCorrection.h
@@ -33,12 +33,10 @@ public:
 
     virtual std::pair<bool, Eigen::VectorXd> getLikelihood();
 
+
 protected:
-    GaussianCorrection() noexcept;
-
-    GaussianCorrection(GaussianCorrection&& gaussian_correction) noexcept;
-
     virtual void correctStep(const GaussianMixture& pred_state, GaussianMixture& corr_state) = 0;
+
 
 private:
     bool skip_ = false;

--- a/src/BayesFilters/include/BayesFilters/GaussianCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/GaussianCorrection.h
@@ -21,7 +21,7 @@ namespace bfl {
 class bfl::GaussianCorrection
 {
 public:
-    virtual ~GaussianCorrection() noexcept { };
+    virtual ~GaussianCorrection() noexcept = default;
 
     void correct(const GaussianMixture& pred_state, GaussianMixture& corr_state);
 

--- a/src/BayesFilters/include/BayesFilters/GaussianFilter.h
+++ b/src/BayesFilters/include/BayesFilters/GaussianFilter.h
@@ -21,8 +21,6 @@ namespace bfl {
 class bfl::GaussianFilter: public bfl::FilteringAlgorithm
 {
 public:
-    virtual ~GaussianFilter() noexcept;
-
     bool skip(const std::string& what_step, const bool status) override;
 
 protected:
@@ -31,6 +29,8 @@ protected:
     GaussianFilter(GaussianFilter&& kf) noexcept;
 
     GaussianFilter& operator=(GaussianFilter&& gf) noexcept;
+
+    virtual ~GaussianFilter() noexcept = default;
 
     std::unique_ptr<GaussianPrediction> prediction_;
 

--- a/src/BayesFilters/include/BayesFilters/GaussianFilter.h
+++ b/src/BayesFilters/include/BayesFilters/GaussianFilter.h
@@ -18,12 +18,9 @@ namespace bfl {
 }
 
 
-class bfl::GaussianFilter: public bfl::FilteringAlgorithm
+class bfl::GaussianFilter : public bfl::FilteringAlgorithm
 {
 public:
-    bool skip(const std::string& what_step, const bool status) override;
-
-protected:
     GaussianFilter(std::unique_ptr<GaussianPrediction> prediction, std::unique_ptr<GaussianCorrection> correction) noexcept;
 
     GaussianFilter(GaussianFilter&& kf) noexcept;
@@ -32,6 +29,10 @@ protected:
 
     virtual ~GaussianFilter() noexcept = default;
 
+    bool skip(const std::string& what_step, const bool status) override;
+
+
+protected:
     std::unique_ptr<GaussianPrediction> prediction_;
 
     std::unique_ptr<GaussianCorrection> correction_;

--- a/src/BayesFilters/include/BayesFilters/GaussianInitialization.h
+++ b/src/BayesFilters/include/BayesFilters/GaussianInitialization.h
@@ -20,7 +20,7 @@ namespace bfl {
 class bfl::GaussianInitialization
 {
 public:
-    virtual ~GaussianInitialization() noexcept { };
+    virtual ~GaussianInitialization() noexcept = default;
 
     virtual void initialize(Gaussian& state) = 0;
 };

--- a/src/BayesFilters/include/BayesFilters/GaussianLikelihood.h
+++ b/src/BayesFilters/include/BayesFilters/GaussianLikelihood.h
@@ -22,7 +22,8 @@ public:
 
     GaussianLikelihood(const double scale_factor) noexcept;
 
-    virtual ~GaussianLikelihood() noexcept { };
+    virtual ~GaussianLikelihood() noexcept = default;
+
 
 protected:
     std::pair<bool, Eigen::VectorXd> likelihood(const MeasurementModel& measurement_model, const Eigen::Ref<const Eigen::MatrixXd>& pred_states) override;

--- a/src/BayesFilters/include/BayesFilters/GaussianMixture.h
+++ b/src/BayesFilters/include/BayesFilters/GaussianMixture.h
@@ -26,7 +26,7 @@ public:
 
     GaussianMixture(const std::size_t components, const std::size_t dim_linear, const std::size_t dim_circular, const bool use_quaternion = false) noexcept;
 
-    virtual ~GaussianMixture() noexcept;
+    virtual ~GaussianMixture() noexcept = default;
 
     virtual void resize(const std::size_t components, const std::size_t dim_linear, const std::size_t dim_circular = 0);
 

--- a/src/BayesFilters/include/BayesFilters/GaussianPrediction.h
+++ b/src/BayesFilters/include/BayesFilters/GaussianPrediction.h
@@ -36,12 +36,10 @@ public:
 
     virtual ExogenousModel& getExogenousModel();
 
+
 protected:
-    GaussianPrediction() noexcept;
-
-    GaussianPrediction(GaussianPrediction&& g_prediction) noexcept;
-
     virtual void predictStep(const GaussianMixture& prev_state, GaussianMixture& pred_state) = 0;
+
 
 private:
     bool skip_prediction_ = false;

--- a/src/BayesFilters/include/BayesFilters/GaussianPrediction.h
+++ b/src/BayesFilters/include/BayesFilters/GaussianPrediction.h
@@ -38,6 +38,16 @@ public:
 
 
 protected:
+    GaussianPrediction() noexcept = default;
+
+    GaussianPrediction(const GaussianPrediction& prediction) noexcept = delete;
+
+    GaussianPrediction& operator=(const GaussianPrediction& prediction) noexcept = delete;
+
+    GaussianPrediction(GaussianPrediction&& prediction) noexcept = default;
+
+    GaussianPrediction& operator=(GaussianPrediction&& prediction) noexcept = default;
+
     virtual void predictStep(const GaussianMixture& prev_state, GaussianMixture& pred_state) = 0;
 
 

--- a/src/BayesFilters/include/BayesFilters/GaussianPrediction.h
+++ b/src/BayesFilters/include/BayesFilters/GaussianPrediction.h
@@ -22,7 +22,7 @@ namespace bfl {
 class bfl::GaussianPrediction
 {
 public:
-    virtual ~GaussianPrediction() noexcept;
+    virtual ~GaussianPrediction() noexcept = default;
 
     void predict(const GaussianMixture& prev_state, GaussianMixture& pred_state);
 

--- a/src/BayesFilters/include/BayesFilters/HistoryBuffer.h
+++ b/src/BayesFilters/include/BayesFilters/HistoryBuffer.h
@@ -26,7 +26,7 @@ public:
 
     HistoryBuffer& operator=(HistoryBuffer&& history_buffer) noexcept;
 
-    ~HistoryBuffer() noexcept { };
+    ~HistoryBuffer() noexcept = default;
 
     void addElement(const Eigen::Ref<const Eigen::VectorXd>& element);
 

--- a/src/BayesFilters/include/BayesFilters/HistoryBuffer.h
+++ b/src/BayesFilters/include/BayesFilters/HistoryBuffer.h
@@ -42,6 +42,7 @@ public:
 
     bool clear();
 
+
 private:
     unsigned int window_ = 5;
 

--- a/src/BayesFilters/include/BayesFilters/InitSurveillanceAreaGrid.h
+++ b/src/BayesFilters/include/BayesFilters/InitSurveillanceAreaGrid.h
@@ -18,15 +18,14 @@ namespace bfl {
 class bfl::InitSurveillanceAreaGrid : public ParticleSetInitialization
 {
 public:
-    InitSurveillanceAreaGrid(const double surv_x_inf, const double surv_x_sup, const double surv_y_inf, const double surv_y_sup,
-                             const unsigned int num_particle_x, const unsigned int num_particle_y) noexcept;
+    InitSurveillanceAreaGrid(const double surv_x_inf, const double surv_x_sup, const double surv_y_inf, const double surv_y_sup, const unsigned int num_particle_x, const unsigned int num_particle_y) noexcept;
 
-    InitSurveillanceAreaGrid(const double surv_x, const double surv_y,
-                             const unsigned int num_particle_x, const unsigned int num_particle_y) noexcept;
+    InitSurveillanceAreaGrid(const double surv_x, const double surv_y, const unsigned int num_particle_x, const unsigned int num_particle_y) noexcept;
 
     virtual ~InitSurveillanceAreaGrid() noexcept = default;
 
     bool initialize(bfl::ParticleSet& particles) override;
+
 
 protected:
     double surv_x_inf_;

--- a/src/BayesFilters/include/BayesFilters/InitSurveillanceAreaGrid.h
+++ b/src/BayesFilters/include/BayesFilters/InitSurveillanceAreaGrid.h
@@ -24,7 +24,7 @@ public:
     InitSurveillanceAreaGrid(const double surv_x, const double surv_y,
                              const unsigned int num_particle_x, const unsigned int num_particle_y) noexcept;
 
-    virtual ~InitSurveillanceAreaGrid() noexcept { };
+    virtual ~InitSurveillanceAreaGrid() noexcept = default;
 
     bool initialize(bfl::ParticleSet& particles) override;
 

--- a/src/BayesFilters/include/BayesFilters/KFCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/KFCorrection.h
@@ -35,6 +35,8 @@ public:
 protected:
     void correctStep(const GaussianMixture& pred_state, GaussianMixture& corr_state) override;
 
+
+private:
     std::unique_ptr<LinearMeasurementModel> measurement_model_;
 
     Eigen::MatrixXd innovations_;

--- a/src/BayesFilters/include/BayesFilters/KFCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/KFCorrection.h
@@ -26,7 +26,7 @@ public:
 
     KFCorrection(KFCorrection&& kf_prediction) noexcept;
 
-    virtual ~KFCorrection() noexcept;
+    virtual ~KFCorrection() noexcept = default;
 
     MeasurementModel& getMeasurementModel() override;
 

--- a/src/BayesFilters/include/BayesFilters/KFPrediction.h
+++ b/src/BayesFilters/include/BayesFilters/KFPrediction.h
@@ -35,6 +35,7 @@ public:
 
     ExogenousModel& getExogenousModel() override;
 
+
 protected:
     void predictStep(const GaussianMixture& prev_state, GaussianMixture& pred_state) override;
 

--- a/src/BayesFilters/include/BayesFilters/KFPrediction.h
+++ b/src/BayesFilters/include/BayesFilters/KFPrediction.h
@@ -29,7 +29,7 @@ public:
 
     KFPrediction(KFPrediction&& kf_prediction) noexcept;
 
-    virtual ~KFPrediction() noexcept;
+    virtual ~KFPrediction() noexcept = default;
 
     StateModel& getStateModel() noexcept override;
 

--- a/src/BayesFilters/include/BayesFilters/LTIMeasurementModel.h
+++ b/src/BayesFilters/include/BayesFilters/LTIMeasurementModel.h
@@ -22,7 +22,7 @@ class bfl::LTIMeasurementModel : public bfl::LinearMeasurementModel
 public:
     LTIMeasurementModel(const Eigen::Ref<const Eigen::MatrixXd>& measurement_matrix, const Eigen::Ref<const Eigen::MatrixXd>& noise_covariance_matrix);
 
-    virtual ~LTIMeasurementModel() noexcept { };
+    virtual ~LTIMeasurementModel() noexcept = default;
 
     std::pair<bool, Eigen::MatrixXd> getNoiseCovarianceMatrix() const override;
 

--- a/src/BayesFilters/include/BayesFilters/LTIMeasurementModel.h
+++ b/src/BayesFilters/include/BayesFilters/LTIMeasurementModel.h
@@ -28,6 +28,7 @@ public:
 
     Eigen::MatrixXd getMeasurementMatrix() const override;
 
+
 protected:
     /* Measurement matrix. */
     Eigen::MatrixXd H_;

--- a/src/BayesFilters/include/BayesFilters/LTIStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/LTIStateModel.h
@@ -34,6 +34,7 @@ public:
 
     Eigen::MatrixXd getJacobian() override;
 
+
 protected:
     /*
      * State transition matrix.

--- a/src/BayesFilters/include/BayesFilters/LTIStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/LTIStateModel.h
@@ -22,7 +22,7 @@ class bfl::LTIStateModel : public bfl::LinearStateModel
 public:
     LTIStateModel(const Eigen::Ref<const Eigen::MatrixXd>& transition_matrix, const Eigen::Ref<const Eigen::MatrixXd>& noise_covariance_matrix);
 
-    virtual ~LTIStateModel() noexcept { };
+    virtual ~LTIStateModel() noexcept = default;
 
     void propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> prop_states) override;
 

--- a/src/BayesFilters/include/BayesFilters/LikelihoodModel.h
+++ b/src/BayesFilters/include/BayesFilters/LikelihoodModel.h
@@ -20,7 +20,7 @@ namespace bfl {
 class bfl::LikelihoodModel
 {
 public:
-    virtual ~LikelihoodModel() noexcept { };
+    virtual ~LikelihoodModel() noexcept = default;
 
     virtual std::pair<bool, Eigen::VectorXd> likelihood(const MeasurementModel& measurement_model, const Eigen::Ref<const Eigen::MatrixXd>& pred_states) = 0;
 };

--- a/src/BayesFilters/include/BayesFilters/LinearMeasurementModel.h
+++ b/src/BayesFilters/include/BayesFilters/LinearMeasurementModel.h
@@ -20,7 +20,7 @@ namespace bfl {
 class bfl::LinearMeasurementModel : public bfl::AdditiveMeasurementModel
 {
 public:
-    virtual ~LinearMeasurementModel() noexcept { };
+    virtual ~LinearMeasurementModel() noexcept = default;
 
     virtual Eigen::MatrixXd getMeasurementMatrix() const = 0;
 

--- a/src/BayesFilters/include/BayesFilters/LinearModel.h
+++ b/src/BayesFilters/include/BayesFilters/LinearModel.h
@@ -33,7 +33,7 @@ public:
 
     LinearModel(LinearModel&& lin_sense) noexcept;
 
-    virtual ~LinearModel() noexcept;
+    virtual ~LinearModel() noexcept = default;
 
     LinearModel& operator=(const LinearModel& lin_sense) noexcept;
 

--- a/src/BayesFilters/include/BayesFilters/LinearModel.h
+++ b/src/BayesFilters/include/BayesFilters/LinearModel.h
@@ -43,14 +43,6 @@ public:
 
     Eigen::MatrixXd getMeasurementMatrix() const override;
 
-private:
-    std::mt19937_64 generator_;
-
-    std::normal_distribution<double> distribution_;
-
-    bool log_enabled_ = false;
-
-    mutable std::ofstream log_file_measurements_;
 
 protected:
     std::pair<bool, Eigen::MatrixXd> getNoiseSample(const int num) const;
@@ -95,6 +87,16 @@ protected:
     {
         return {folder_path + "/" + file_name_prefix + "_measurements"};
     }
+
+
+private:
+    std::mt19937_64 generator_;
+
+    std::normal_distribution<double> distribution_;
+
+    bool log_enabled_ = false;
+
+    mutable std::ofstream log_file_measurements_;
 };
 
 #endif /* LINEARMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/LinearStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/LinearStateModel.h
@@ -20,7 +20,7 @@ namespace bfl {
 class bfl::LinearStateModel : public bfl::AdditiveStateModel
 {
 public:
-    virtual ~LinearStateModel() noexcept { };
+    virtual ~LinearStateModel() noexcept = default;
 
     virtual void propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> mot_states) override;
 

--- a/src/BayesFilters/include/BayesFilters/Logger.h
+++ b/src/BayesFilters/include/BayesFilters/Logger.h
@@ -59,10 +59,12 @@ public:
             logger_helper(0, data...);
     }
 
+
 protected:
     virtual std::vector<std::string> log_file_names(const std::string& folder_path, const std::string& file_name_prefix);
 
     virtual void log();
+
 
 private:
     std::string folder_path_;

--- a/src/BayesFilters/include/BayesFilters/MeasurementModel.h
+++ b/src/BayesFilters/include/BayesFilters/MeasurementModel.h
@@ -25,7 +25,7 @@ namespace bfl {
 class bfl::MeasurementModel : public Logger
 {
 public:
-    virtual ~MeasurementModel() noexcept;
+    virtual ~MeasurementModel() noexcept = default;
 
     virtual bool freeze(const Data& data = Data()) = 0;
 

--- a/src/BayesFilters/include/BayesFilters/PFCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/PFCorrection.h
@@ -43,6 +43,7 @@ public:
 
     virtual std::pair<bool, Eigen::VectorXd> getLikelihood() = 0;
 
+
 protected:
     virtual void correctStep(const ParticleSet& pred_particles, ParticleSet& cor_particles) = 0;
 

--- a/src/BayesFilters/include/BayesFilters/PFCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/PFCorrection.h
@@ -25,7 +25,7 @@ namespace bfl {
 class bfl::PFCorrection
 {
 public:
-    virtual ~PFCorrection() noexcept { };
+    virtual ~PFCorrection() noexcept = default;
 
     void correct(const ParticleSet& pred_particles, ParticleSet& cor_particles);
 

--- a/src/BayesFilters/include/BayesFilters/PFCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/PFCorrection.h
@@ -29,22 +29,28 @@ public:
 
     void correct(const ParticleSet& pred_particles, ParticleSet& cor_particles);
 
-    bool skip(const bool status);
-
-    virtual void setLikelihoodModel(std::unique_ptr<LikelihoodModel> observation_model) = 0;
-
-    virtual void setMeasurementModel(std::unique_ptr<MeasurementModel> measurement_model) = 0;
-
-    virtual LikelihoodModel& getLikelihoodModel() = 0;
-
-    virtual MeasurementModel& getMeasurementModel() = 0;
+    bool skip(const bool status) noexcept;
 
     bool freeze_measurements();
+
+    virtual MeasurementModel& getMeasurementModel() noexcept = 0;
+
+    virtual LikelihoodModel& getLikelihoodModel() noexcept = 0;
 
     virtual std::pair<bool, Eigen::VectorXd> getLikelihood() = 0;
 
 
 protected:
+    PFCorrection() noexcept = default;
+
+    PFCorrection(const PFCorrection& correction) noexcept = delete;
+
+    PFCorrection& operator=(const PFCorrection& correction) noexcept = delete;
+
+    PFCorrection(PFCorrection&& correction) noexcept = default;
+
+    PFCorrection& operator=(PFCorrection&& correction) noexcept = default;
+
     virtual void correctStep(const ParticleSet& pred_particles, ParticleSet& cor_particles) = 0;
 
 

--- a/src/BayesFilters/include/BayesFilters/PFCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/PFCorrection.h
@@ -46,7 +46,6 @@ public:
 protected:
     virtual void correctStep(const ParticleSet& pred_particles, ParticleSet& cor_particles) = 0;
 
-    PFCorrection() noexcept;
 
 private:
     bool skip_ = false;

--- a/src/BayesFilters/include/BayesFilters/PFPrediction.h
+++ b/src/BayesFilters/include/BayesFilters/PFPrediction.h
@@ -24,7 +24,7 @@ namespace bfl {
 class bfl::PFPrediction
 {
 public:
-    virtual ~PFPrediction() noexcept { };
+    virtual ~PFPrediction() noexcept = default;
 
     void predict(const ParticleSet& prev_particles, ParticleSet& pred_particles);
 

--- a/src/BayesFilters/include/BayesFilters/PFPrediction.h
+++ b/src/BayesFilters/include/BayesFilters/PFPrediction.h
@@ -34,19 +34,21 @@ public:
 
     bool getSkipExogenous();
 
-    virtual void setStateModel(std::unique_ptr<StateModel> state_model) = 0;
-
-    virtual void setExogenousModel(std::unique_ptr<ExogenousModel> exogenous_model);
-
-    virtual StateModel& getStateModel() = 0;
+    virtual StateModel& getStateModel() noexcept = 0;
 
     virtual ExogenousModel& getExogenousModel();
 
 
 protected:
-    PFPrediction() noexcept;
+    PFPrediction() noexcept = default;
 
-    PFPrediction(PFPrediction&& pf_prediction) noexcept;
+    PFPrediction(const PFPrediction& prediction) noexcept = delete;
+
+    PFPrediction& operator=(const PFPrediction& prediction) noexcept = delete;
+
+    PFPrediction(PFPrediction&& prediction) noexcept = default;
+
+    PFPrediction& operator=(PFPrediction&& prediction) noexcept = default;
 
     virtual void predictStep(const ParticleSet& prev_particles, ParticleSet& pred_particles) = 0;
 

--- a/src/BayesFilters/include/BayesFilters/PFPrediction.h
+++ b/src/BayesFilters/include/BayesFilters/PFPrediction.h
@@ -42,12 +42,14 @@ public:
 
     virtual ExogenousModel& getExogenousModel();
 
+
 protected:
     PFPrediction() noexcept;
 
     PFPrediction(PFPrediction&& pf_prediction) noexcept;
 
     virtual void predictStep(const ParticleSet& prev_particles, ParticleSet& pred_particles) = 0;
+
 
 private:
     bool skip_prediction_ = false;

--- a/src/BayesFilters/include/BayesFilters/ParticleFilter.h
+++ b/src/BayesFilters/include/BayesFilters/ParticleFilter.h
@@ -26,7 +26,8 @@ class bfl::ParticleFilter : public FilteringAlgorithm
 public:
     virtual bool skip(const std::string& what_step, const bool status) override;
 
-    virtual ~ParticleFilter() noexcept;
+    virtual ~ParticleFilter() noexcept = default;
+
 
 protected:
     ParticleFilter(std::unique_ptr<ParticleSetInitialization> initialization, std::unique_ptr<PFPrediction> prediction, std::unique_ptr<PFCorrection> correction, std::unique_ptr<Resampling> resampling) noexcept;

--- a/src/BayesFilters/include/BayesFilters/ParticleSet.h
+++ b/src/BayesFilters/include/BayesFilters/ParticleSet.h
@@ -44,9 +44,11 @@ public:
 
     const double& state(const std::size_t i, const std::size_t j) const;
 
+
 protected:
     Eigen::MatrixXd state_;
 };
+
 
 bfl::ParticleSet operator+(bfl::ParticleSet lhs, const bfl::ParticleSet& rhs);
 

--- a/src/BayesFilters/include/BayesFilters/ParticleSet.h
+++ b/src/BayesFilters/include/BayesFilters/ParticleSet.h
@@ -26,7 +26,7 @@ public:
 
     ParticleSet(const std::size_t components, const std::size_t dim_linear, const std::size_t dim_circular, const bool use_quaternion = false) noexcept;
 
-    virtual ~ParticleSet() noexcept;
+    virtual ~ParticleSet() noexcept = default;
 
     void resize(const std::size_t components, const std::size_t dim_linear, const std::size_t dim_circular = 0) override;
 

--- a/src/BayesFilters/include/BayesFilters/ParticleSetInitialization.h
+++ b/src/BayesFilters/include/BayesFilters/ParticleSetInitialization.h
@@ -20,7 +20,7 @@ namespace bfl {
 class bfl::ParticleSetInitialization
 {
 public:
-    virtual ~ParticleSetInitialization() noexcept { };
+    virtual ~ParticleSetInitialization() noexcept = default;
 
     virtual bool initialize(ParticleSet& particles) = 0;
 };

--- a/src/BayesFilters/include/BayesFilters/Resampling.h
+++ b/src/BayesFilters/include/BayesFilters/Resampling.h
@@ -30,7 +30,7 @@ public:
 
     Resampling(Resampling&& resampling) noexcept;
 
-    virtual ~Resampling() noexcept;
+    virtual ~Resampling() noexcept = default;
 
     Resampling& operator=(const Resampling& resampling);
 

--- a/src/BayesFilters/include/BayesFilters/Resampling.h
+++ b/src/BayesFilters/include/BayesFilters/Resampling.h
@@ -38,10 +38,10 @@ public:
 
     Resampling& operator=(const Resampling&& resampling) noexcept;
 
-    virtual void resample(const bfl::ParticleSet& cor_particles, bfl::ParticleSet& res_particles,
-                          Eigen::Ref<Eigen::VectorXi> res_parents);
+    virtual void resample(const bfl::ParticleSet& cor_particles, bfl::ParticleSet& res_particles, Eigen::Ref<Eigen::VectorXi> res_parents);
 
     virtual double neff(const Eigen::Ref<const Eigen::VectorXd>& cor_weights);
+
 
 private:
     std::mt19937_64 generator_;

--- a/src/BayesFilters/include/BayesFilters/ResamplingWithPrior.h
+++ b/src/BayesFilters/include/BayesFilters/ResamplingWithPrior.h
@@ -33,7 +33,7 @@ public:
 
     ResamplingWithPrior(ResamplingWithPrior&& resampling) noexcept;
 
-    virtual ~ResamplingWithPrior() noexcept;
+    virtual ~ResamplingWithPrior() noexcept = default;
 
     ResamplingWithPrior& operator=(ResamplingWithPrior&& resampling) noexcept;
 

--- a/src/BayesFilters/include/BayesFilters/ResamplingWithPrior.h
+++ b/src/BayesFilters/include/BayesFilters/ResamplingWithPrior.h
@@ -37,13 +37,14 @@ public:
 
     ResamplingWithPrior& operator=(ResamplingWithPrior&& resampling) noexcept;
 
-
     void resample(const ParticleSet& cor_particles, ParticleSet& res_particles, Eigen::Ref<Eigen::VectorXi> res_parents) override;
+
 
 protected:
     std::unique_ptr<bfl::ParticleSetInitialization> init_model_;
 
     double prior_ratio_ = 0.5;
+
 
 private:
     std::vector<unsigned int> sort_indices(const Eigen::Ref<const Eigen::VectorXd>& vector);

--- a/src/BayesFilters/include/BayesFilters/SIS.h
+++ b/src/BayesFilters/include/BayesFilters/SIS.h
@@ -33,7 +33,7 @@ public:
 
     SIS(SIS&& sir_pf) noexcept;
 
-    virtual ~SIS() noexcept;
+    virtual ~SIS() noexcept = default;
 
     SIS& operator=(SIS&& sir_pf) noexcept;
 

--- a/src/BayesFilters/include/BayesFilters/SIS.h
+++ b/src/BayesFilters/include/BayesFilters/SIS.h
@@ -37,6 +37,7 @@ public:
 
     SIS& operator=(SIS&& sir_pf) noexcept;
 
+
 protected:
     unsigned int num_particle_;
 

--- a/src/BayesFilters/include/BayesFilters/SUKFCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/SUKFCorrection.h
@@ -47,7 +47,7 @@ public:
 
     SUKFCorrection(SUKFCorrection&& sukf_correction) noexcept;
 
-    virtual ~SUKFCorrection() noexcept { };
+    virtual ~SUKFCorrection() noexcept = default;
 
     MeasurementModel& getMeasurementModel() override;
 

--- a/src/BayesFilters/include/BayesFilters/SUKFCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/SUKFCorrection.h
@@ -53,10 +53,12 @@ public:
 
     std::pair<bool, Eigen::VectorXd> getLikelihood() override;
 
+
 protected:
     void correctStep(const GaussianMixture& pred_state, GaussianMixture& corr_state) override;
 
     virtual Eigen::MatrixXd getNoiseCovarianceMatrix(const std::size_t index);
+
 
 private:
     std::unique_ptr<MeasurementModel> measurement_model_;

--- a/src/BayesFilters/include/BayesFilters/SimulatedLinearSensor.h
+++ b/src/BayesFilters/include/BayesFilters/SimulatedLinearSensor.h
@@ -35,6 +35,7 @@ public:
 
     std::pair<std::size_t, std::size_t> getOutputSize() const override;
 
+
 protected:
     std::unique_ptr<bfl::SimulatedStateModel> simulated_state_model_;
 

--- a/src/BayesFilters/include/BayesFilters/SimulatedLinearSensor.h
+++ b/src/BayesFilters/include/BayesFilters/SimulatedLinearSensor.h
@@ -27,7 +27,7 @@ public:
 
     SimulatedLinearSensor(std::unique_ptr<bfl::SimulatedStateModel> simulated_state_model);
 
-    virtual ~SimulatedLinearSensor() noexcept;
+    virtual ~SimulatedLinearSensor() noexcept = default;
 
     bool freeze(const Data& data = Data()) override;
 

--- a/src/BayesFilters/include/BayesFilters/SimulatedStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/SimulatedStateModel.h
@@ -35,10 +35,6 @@ public:
 
     StateModel& getStateModel();
 
-private:
-    unsigned int simulation_time_;
-
-    Eigen::MatrixXd target_;
 
 protected:
     std::unique_ptr<StateModel> state_model_;
@@ -57,6 +53,12 @@ protected:
     }
 
     void log() override;
+
+
+private:
+    unsigned int simulation_time_;
+
+    Eigen::MatrixXd target_;
 };
 
 #endif /* SIMULATEDPROCESS_H */

--- a/src/BayesFilters/include/BayesFilters/SimulatedStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/SimulatedStateModel.h
@@ -25,7 +25,7 @@ class bfl::SimulatedStateModel : public Agent, public Logger
 public:
     SimulatedStateModel(std::unique_ptr<StateModel> state_model, const Eigen::Ref<const Eigen::VectorXd>& initial_state, const unsigned int simulation_time);
 
-    virtual ~SimulatedStateModel() noexcept;
+    virtual ~SimulatedStateModel() noexcept = default;
 
     bool bufferData() override;
 

--- a/src/BayesFilters/include/BayesFilters/StateModel.h
+++ b/src/BayesFilters/include/BayesFilters/StateModel.h
@@ -18,7 +18,7 @@ namespace bfl {
 class bfl::StateModel
 {
 public:
-    virtual ~StateModel() noexcept { };
+    virtual ~StateModel() noexcept = default;
 
     virtual void propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> prop_states) = 0;
 

--- a/src/BayesFilters/include/BayesFilters/UKFCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/UKFCorrection.h
@@ -30,7 +30,7 @@ public:
 
     UKFCorrection(UKFCorrection&& ukf_prediction) noexcept;
 
-    virtual ~UKFCorrection() noexcept;
+    virtual ~UKFCorrection() noexcept = default;
 
     MeasurementModel& getMeasurementModel() override;
 

--- a/src/BayesFilters/include/BayesFilters/UKFPrediction.h
+++ b/src/BayesFilters/include/BayesFilters/UKFPrediction.h
@@ -35,7 +35,7 @@ public:
 
     UKFPrediction(UKFPrediction&& ukf_prediction) noexcept;
 
-    virtual ~UKFPrediction() noexcept;
+    virtual ~UKFPrediction() noexcept = default;
 
     StateModel& getStateModel() noexcept override;
 

--- a/src/BayesFilters/include/BayesFilters/UKFPrediction.h
+++ b/src/BayesFilters/include/BayesFilters/UKFPrediction.h
@@ -41,6 +41,7 @@ public:
 
     ExogenousModel& getExogenousModel() override;
 
+
 protected:
     void predictStep(const GaussianMixture& prev_state, GaussianMixture& pred_state) override;
 

--- a/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
+++ b/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
@@ -49,10 +49,12 @@ public:
 
     std::pair<std::size_t, std::size_t> getOutputSize() const override;
 
+
 private:
     std::mt19937_64 generator_;
 
     std::normal_distribution<double> distribution_;
+
 
 protected:
     /**

--- a/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
+++ b/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
@@ -31,7 +31,7 @@ public:
 
     WhiteNoiseAcceleration(WhiteNoiseAcceleration&& wna) noexcept;
 
-    virtual ~WhiteNoiseAcceleration() noexcept;
+    virtual ~WhiteNoiseAcceleration() noexcept = default;
 
     WhiteNoiseAcceleration& operator=(const WhiteNoiseAcceleration& wna);
 

--- a/src/BayesFilters/include/BayesFilters/any.h
+++ b/src/BayesFilters/include/BayesFilters/any.h
@@ -167,8 +167,12 @@ public:
      */
     any& operator=(any&& rhs) noexcept
     {
+        if (this == &rhs)
+            return *this;
+
         rhs.swap(*this);
         any().swap(rhs);
+
         return *this;
     }
 

--- a/src/BayesFilters/include/BayesFilters/any.h
+++ b/src/BayesFilters/include/BayesFilters/any.h
@@ -192,6 +192,7 @@ public:
     any& operator=(ValueType&& rhs)
     {
         any(static_cast<ValueType&&>(rhs)).swap(*this);
+
         return *this;
     }
 
@@ -222,6 +223,7 @@ public:
     any& swap(any& rhs) noexcept
     {
         std::swap(content, rhs.content);
+
         return *this;
     }
 

--- a/src/BayesFilters/src/Agent.cpp
+++ b/src/BayesFilters/src/Agent.cpp
@@ -12,10 +12,6 @@
 using namespace bfl;
 
 
-Agent::~Agent() noexcept
-{ }
-
-
 bool Agent::setProperty(const std::string& property)
 {
     static_cast<void>(property);

--- a/src/BayesFilters/src/BootstrapCorrection.cpp
+++ b/src/BayesFilters/src/BootstrapCorrection.cpp
@@ -18,10 +18,6 @@ BootstrapCorrection::BootstrapCorrection() noexcept
 { }
 
 
-BootstrapCorrection::~BootstrapCorrection() noexcept
-{ }
-
-
 void BootstrapCorrection::correctStep(const ParticleSet& pred_particles, ParticleSet& cor_particles)
 {
     std::tie(valid_likelihood_, likelihood_) = likelihood_model_->likelihood(*measurement_model_, pred_particles.state());

--- a/src/BayesFilters/src/BootstrapCorrection.cpp
+++ b/src/BayesFilters/src/BootstrapCorrection.cpp
@@ -14,10 +14,6 @@ using namespace bfl;
 using namespace Eigen;
 
 
-BootstrapCorrection::BootstrapCorrection() noexcept
-{ }
-
-
 void BootstrapCorrection::correctStep(const ParticleSet& pred_particles, ParticleSet& cor_particles)
 {
     std::tie(valid_likelihood_, likelihood_) = likelihood_model_->likelihood(*measurement_model_, pred_particles.state());

--- a/src/BayesFilters/src/BootstrapCorrection.cpp
+++ b/src/BayesFilters/src/BootstrapCorrection.cpp
@@ -14,9 +14,42 @@ using namespace bfl;
 using namespace Eigen;
 
 
+BootstrapCorrection::BootstrapCorrection(std::unique_ptr<MeasurementModel> measurement_model, std::unique_ptr<LikelihoodModel> likelihood_model) noexcept :
+    measurement_model_(std::move(measurement_model)),
+    likelihood_model_(std::move(likelihood_model))
+{ }
+
+
+BootstrapCorrection::BootstrapCorrection(BootstrapCorrection&& correction) noexcept :
+    PFCorrection(std::move(correction)),
+    measurement_model_(std::move(correction.measurement_model_)),
+    likelihood_model_(std::move(correction.likelihood_model_))
+{ }
+
+
+BootstrapCorrection& BootstrapCorrection::operator=(BootstrapCorrection&& correction) noexcept
+{
+    PFCorrection::operator=(std::move(correction));
+
+    return *this;
+}
+
+
+MeasurementModel& BootstrapCorrection::getMeasurementModel() noexcept
+{
+    return *measurement_model_;
+}
+
+
+LikelihoodModel& BootstrapCorrection::getLikelihoodModel() noexcept
+{
+    return *likelihood_model_;
+}
+
+
 void BootstrapCorrection::correctStep(const ParticleSet& pred_particles, ParticleSet& cor_particles)
 {
-    std::tie(valid_likelihood_, likelihood_) = likelihood_model_->likelihood(*measurement_model_, pred_particles.state());
+    std::tie(valid_likelihood_, likelihood_) = getLikelihoodModel().likelihood(getMeasurementModel(), pred_particles.state());
 
     cor_particles = pred_particles;
 
@@ -25,31 +58,7 @@ void BootstrapCorrection::correctStep(const ParticleSet& pred_particles, Particl
 }
 
 
-LikelihoodModel& BootstrapCorrection::getLikelihoodModel()
-{
-    return *likelihood_model_;
-}
-
-
-MeasurementModel& BootstrapCorrection::getMeasurementModel()
-{
-    return *measurement_model_;
-}
-
-
 std::pair<bool, VectorXd> BootstrapCorrection::getLikelihood()
 {
     return std::make_pair(valid_likelihood_, likelihood_);
-}
-
-
-void BootstrapCorrection::setLikelihoodModel(std::unique_ptr<LikelihoodModel> likelihood_model)
-{
-    likelihood_model_ = std::move(likelihood_model);
-}
-
-
-void BootstrapCorrection::setMeasurementModel(std::unique_ptr<MeasurementModel> measurement_model)
-{
-    measurement_model_ = std::move(measurement_model);
 }

--- a/src/BayesFilters/src/DrawParticles.cpp
+++ b/src/BayesFilters/src/DrawParticles.cpp
@@ -17,10 +17,8 @@ DrawParticles::DrawParticles() noexcept { }
 
 
 DrawParticles::DrawParticles(DrawParticles&& draw_particles) noexcept :
-    PFPrediction(std::move(draw_particles)) { };
-
-
-DrawParticles::~DrawParticles() noexcept { }
+    PFPrediction(std::move(draw_particles))
+{ };
 
 
 void DrawParticles::predictStep(const ParticleSet& prev_particles, ParticleSet& pred_particles)

--- a/src/BayesFilters/src/DrawParticles.cpp
+++ b/src/BayesFilters/src/DrawParticles.cpp
@@ -13,7 +13,8 @@ using namespace bfl;
 using namespace Eigen;
 
 
-DrawParticles::DrawParticles() noexcept { }
+DrawParticles::DrawParticles() noexcept
+{ }
 
 
 DrawParticles::DrawParticles(DrawParticles&& draw_particles) noexcept :

--- a/src/BayesFilters/src/DrawParticles.cpp
+++ b/src/BayesFilters/src/DrawParticles.cpp
@@ -13,29 +13,45 @@ using namespace bfl;
 using namespace Eigen;
 
 
-DrawParticles::DrawParticles() noexcept
+DrawParticles::DrawParticles(std::unique_ptr<StateModel> state_model) noexcept :
+    state_model_(std::move(state_model))
 { }
 
 
-DrawParticles::DrawParticles(DrawParticles&& draw_particles) noexcept :
-    PFPrediction(std::move(draw_particles))
-{ };
+DrawParticles::DrawParticles(std::unique_ptr<StateModel> state_model, std::unique_ptr<ExogenousModel> exogenous_model) noexcept :
+    state_model_(std::move(state_model)),
+    exogenous_model_(std::move(exogenous_model))
+{ }
 
 
-void DrawParticles::predictStep(const ParticleSet& prev_particles, ParticleSet& pred_particles)
+DrawParticles::DrawParticles(DrawParticles&& prediction) noexcept :
+    PFPrediction(std::move(prediction)),
+    state_model_(std::move(prediction.state_model_)),
+    exogenous_model_(std::move(prediction.exogenous_model_))
+{ }
+
+
+DrawParticles& DrawParticles::operator=(DrawParticles&& prediction) noexcept
 {
-    state_model_->motion(prev_particles.state(), pred_particles.state());
+    PFPrediction::operator=(std::move(prediction));
 
-    pred_particles.weight() = prev_particles.weight();
+    state_model_ = std::move(prediction.state_model_);
+
+    exogenous_model_ = std::move(prediction.exogenous_model_);
+
+    return *this;
 }
 
-StateModel& DrawParticles::getStateModel()
+
+StateModel& DrawParticles::getStateModel() noexcept
 {
     return *state_model_;
 }
 
 
-void DrawParticles::setStateModel(std::unique_ptr<StateModel> state_model)
+void DrawParticles::predictStep(const ParticleSet& prev_particles, ParticleSet& pred_particles)
 {
-    state_model_ = std::move(state_model);
+    getStateModel().motion(prev_particles.state(), pred_particles.state());
+
+    pred_particles.weight() = prev_particles.weight();
 }

--- a/src/BayesFilters/src/EstimatesExtraction.cpp
+++ b/src/BayesFilters/src/EstimatesExtraction.cpp
@@ -42,21 +42,21 @@ EstimatesExtraction::EstimatesExtraction(EstimatesExtraction&& estimate_extracti
 
 EstimatesExtraction& EstimatesExtraction::operator=(EstimatesExtraction&& estimate_extraction) noexcept
 {
-    if (this != &estimate_extraction)
-    {
-        extraction_method_ = estimate_extraction.extraction_method_;
-        estimate_extraction.extraction_method_ = ExtractionMethod::emode;
+    if (this == &estimate_extraction)
+        return *this;
 
-        hist_buffer_ = std::move(estimate_extraction.hist_buffer_);
+    extraction_method_ = estimate_extraction.extraction_method_;
+    estimate_extraction.extraction_method_ = ExtractionMethod::emode;
 
-        sm_weights_ = std::move(estimate_extraction.sm_weights_);
-        wm_weights_ = std::move(estimate_extraction.wm_weights_);
-        em_weights_ = std::move(estimate_extraction.em_weights_);
+    hist_buffer_ = std::move(estimate_extraction.hist_buffer_);
 
-        linear_size_ = estimate_extraction.linear_size_;
-        circular_size_ = estimate_extraction.circular_size_;
-        state_size_ = estimate_extraction.state_size_;
-    }
+    sm_weights_ = std::move(estimate_extraction.sm_weights_);
+    wm_weights_ = std::move(estimate_extraction.wm_weights_);
+    em_weights_ = std::move(estimate_extraction.em_weights_);
+
+    linear_size_ = estimate_extraction.linear_size_;
+    circular_size_ = estimate_extraction.circular_size_;
+    state_size_ = estimate_extraction.state_size_;
 
     return *this;
 }

--- a/src/BayesFilters/src/GPFPrediction.cpp
+++ b/src/BayesFilters/src/GPFPrediction.cpp
@@ -13,30 +13,34 @@ using namespace bfl;
 using namespace Eigen;
 
 
-GPFPrediction::GPFPrediction(std::unique_ptr<GaussianPrediction> gauss_pred) noexcept :
-    gaussian_prediction_(std::move(gauss_pred))
+GPFPrediction::GPFPrediction(std::unique_ptr<GaussianPrediction> gauss_prediction) noexcept :
+    gaussian_prediction_(std::move(gauss_prediction))
 { }
 
 
-GPFPrediction::GPFPrediction(GPFPrediction&& gpf_prediction) noexcept :
-    PFPrediction(std::move(gpf_prediction)),
-    gaussian_prediction_(std::move(gpf_prediction.gaussian_prediction_))
+GPFPrediction::GPFPrediction(GPFPrediction&& prediction) noexcept :
+    PFPrediction(std::move(prediction)),
+    gaussian_prediction_(std::move(prediction.gaussian_prediction_))
 { }
 
 
-StateModel& GPFPrediction::getStateModel()
+GPFPrediction& GPFPrediction::operator=(GPFPrediction&& prediction) noexcept
+{
+    PFPrediction::operator=(std::move(prediction));
+
+    gaussian_prediction_ = std::move(prediction.gaussian_prediction_);
+
+    return *this;
+}
+
+
+StateModel& GPFPrediction::getStateModel() noexcept
 {
     return gaussian_prediction_->getStateModel();
 }
 
 
-void GPFPrediction::setStateModel(std::unique_ptr<StateModel> state_model)
-{
-    throw std::runtime_error("ERROR::GPFPREDICTION::GETSTATEMODEL\nERROR:\n\tCall to unimplemented base class method.");
-}
-
-
-void GPFPrediction::predictStep(const bfl::ParticleSet& prev_particles, bfl::ParticleSet& pred_particles)
+void GPFPrediction::predictStep(const ParticleSet& prev_particles, ParticleSet& pred_particles)
 {
     /* Set skip flags within the Gaussian prediction. */
     gaussian_prediction_->skip("state", getSkipState());

--- a/src/BayesFilters/src/Gaussian.cpp
+++ b/src/BayesFilters/src/Gaussian.cpp
@@ -32,10 +32,6 @@ Gaussian::Gaussian
 { }
 
 
-Gaussian::~Gaussian() noexcept
-{ }
-
-
 void Gaussian::resize(const std::size_t dim_linear, const std::size_t dim_circular)
 {
     GaussianMixture::resize(1, dim_linear, dim_circular);

--- a/src/BayesFilters/src/GaussianCorrection.cpp
+++ b/src/BayesFilters/src/GaussianCorrection.cpp
@@ -7,11 +7,10 @@
 
 #include <BayesFilters/GaussianCorrection.h>
 
+#include <exception>
+
 using namespace bfl;
 using namespace Eigen;
-
-
-GaussianCorrection::GaussianCorrection() noexcept { };
 
 
 void GaussianCorrection::correct(const GaussianMixture& pred_state, GaussianMixture& corr_state)

--- a/src/BayesFilters/src/GaussianFilter.cpp
+++ b/src/BayesFilters/src/GaussianFilter.cpp
@@ -10,11 +10,7 @@
 using namespace bfl;
 
 
-GaussianFilter::GaussianFilter
-(
-    std::unique_ptr<GaussianPrediction> prediction,
-    std::unique_ptr<GaussianCorrection> correction
-) noexcept :
+GaussianFilter::GaussianFilter(std::unique_ptr<GaussianPrediction> prediction, std::unique_ptr<GaussianCorrection> correction) noexcept :
     prediction_(std::move(prediction)),
     correction_(std::move(correction))
 { }

--- a/src/BayesFilters/src/GaussianFilter.cpp
+++ b/src/BayesFilters/src/GaussianFilter.cpp
@@ -38,10 +38,6 @@ GaussianFilter& GaussianFilter::operator=(GaussianFilter&& gf) noexcept
 }
 
 
-GaussianFilter::~GaussianFilter() noexcept
-{ }
-
-
 bool GaussianFilter::skip(const std::string& what_step, const bool status)
 {
     if (what_step == "prediction" ||

--- a/src/BayesFilters/src/GaussianFilter.cpp
+++ b/src/BayesFilters/src/GaussianFilter.cpp
@@ -26,6 +26,18 @@ GaussianFilter::GaussianFilter(GaussianFilter&& gf) noexcept :
 { }
 
 
+GaussianFilter& GaussianFilter::operator=(GaussianFilter&& gf) noexcept
+{
+    if (this == &gf)
+        return *this;
+
+    prediction_ = std::move(gf.prediction_);
+    correction_ = std::move(gf.correction_);
+
+    return *this;
+}
+
+
 GaussianFilter::~GaussianFilter() noexcept
 { }
 

--- a/src/BayesFilters/src/GaussianMixture.cpp
+++ b/src/BayesFilters/src/GaussianMixture.cpp
@@ -61,10 +61,6 @@ GaussianMixture::GaussianMixture
 }
 
 
-GaussianMixture::~GaussianMixture() noexcept
-{ }
-
-
 void GaussianMixture::resize(const std::size_t components, const std::size_t dim_linear, const std::size_t dim_circular)
 {
     std::size_t new_dim = dim_linear + dim_circular * dim_circular_component;

--- a/src/BayesFilters/src/GaussianPrediction.cpp
+++ b/src/BayesFilters/src/GaussianPrediction.cpp
@@ -14,14 +14,6 @@ using namespace bfl;
 using namespace Eigen;
 
 
-GaussianPrediction::GaussianPrediction() noexcept
-{ }
-
-
-
-GaussianPrediction::GaussianPrediction(GaussianPrediction&& g_prediction) noexcept
-{ }
-
 
 void GaussianPrediction::predict(const GaussianMixture& prev_state, GaussianMixture& pred_state)
 {

--- a/src/BayesFilters/src/GaussianPrediction.cpp
+++ b/src/BayesFilters/src/GaussianPrediction.cpp
@@ -18,9 +18,6 @@ GaussianPrediction::GaussianPrediction() noexcept
 { }
 
 
-GaussianPrediction::~GaussianPrediction() noexcept
-{ }
-
 
 GaussianPrediction::GaussianPrediction(GaussianPrediction&& g_prediction) noexcept
 { }

--- a/src/BayesFilters/src/GaussianPrediction.cpp
+++ b/src/BayesFilters/src/GaussianPrediction.cpp
@@ -63,6 +63,7 @@ bool GaussianPrediction::getSkipExogenous()
     return skip_exogenous_;
 }
 
+
 ExogenousModel& GaussianPrediction::getExogenousModel()
 {
     throw std::runtime_error("ERROR::GAUSSIANPREDICTION::GETEXOGENOUSMODEL\nERROR:\n\tCall to unimplemented base class method.");

--- a/src/BayesFilters/src/GaussianPrediction.cpp
+++ b/src/BayesFilters/src/GaussianPrediction.cpp
@@ -38,11 +38,24 @@ void GaussianPrediction::predict(const GaussianMixture& prev_state, GaussianMixt
 bool GaussianPrediction::skip(const std::string& what_step, const bool status)
 {
     if (what_step == "prediction")
+    {
         skip_prediction_ = status;
-    else if (what_step == "state")
+
         skip_state_ = status;
-    else if (what_step == "exogenous")
         skip_exogenous_ = status;
+    }
+    else if (what_step == "state")
+    {
+        skip_state_ = status;
+
+        skip_prediction_ = skip_state_ & skip_exogenous_;
+    }
+    else if (what_step == "exogenous")
+    {
+        skip_exogenous_ = status;
+
+        skip_prediction_ = skip_state_ & skip_exogenous_;
+    }
     else
         return false;
 

--- a/src/BayesFilters/src/HistoryBuffer.cpp
+++ b/src/BayesFilters/src/HistoryBuffer.cpp
@@ -28,16 +28,16 @@ HistoryBuffer::HistoryBuffer(HistoryBuffer&& history_buffer) noexcept :
 
 HistoryBuffer& HistoryBuffer::operator=(HistoryBuffer&& history_buffer) noexcept
 {
-    if (this != &history_buffer)
-    {
-        window_ = history_buffer.window_;
-        history_buffer.window_ = 0;
+    if (this == &history_buffer)
+        return *this;
 
-        state_size_ = history_buffer.state_size_;
-        history_buffer.state_size_ = 0;
+    window_ = history_buffer.window_;
+    history_buffer.window_ = 0;
 
-        history_buffer_ = std::move(history_buffer.history_buffer_);
-    }
+    state_size_ = history_buffer.state_size_;
+    history_buffer.state_size_ = 0;
+
+    history_buffer_ = std::move(history_buffer.history_buffer_);
 
     return *this;
 }

--- a/src/BayesFilters/src/KFCorrection.cpp
+++ b/src/BayesFilters/src/KFCorrection.cpp
@@ -22,10 +22,6 @@ KFCorrection::KFCorrection(KFCorrection&& kf_correction) noexcept :
 { }
 
 
-KFCorrection::~KFCorrection() noexcept
-{ }
-
-
 MeasurementModel& KFCorrection::getMeasurementModel()
 {
     return *measurement_model_;

--- a/src/BayesFilters/src/KFPrediction.cpp
+++ b/src/BayesFilters/src/KFPrediction.cpp
@@ -28,10 +28,6 @@ KFPrediction::KFPrediction(KFPrediction&& kf_prediction) noexcept:
 { }
 
 
-KFPrediction::~KFPrediction() noexcept
-{ }
-
-
 bfl::StateModel& KFPrediction::getStateModel() noexcept
 {
     return *state_model_;

--- a/src/BayesFilters/src/LinearModel.cpp
+++ b/src/BayesFilters/src/LinearModel.cpp
@@ -49,10 +49,6 @@ LinearModel::LinearModel() noexcept :
 { }
 
 
-LinearModel::~LinearModel() noexcept
-{ }
-
-
 LinearModel::LinearModel(const LinearModel& lin_sense) :
     sigma_x_(lin_sense.sigma_x_),
     sigma_y_(lin_sense.sigma_y_),

--- a/src/BayesFilters/src/LinearModel.cpp
+++ b/src/BayesFilters/src/LinearModel.cpp
@@ -115,6 +115,9 @@ LinearModel& LinearModel::operator=(const LinearModel& lin_sense) noexcept
 
 LinearModel& LinearModel::operator=(LinearModel&& lin_sense) noexcept
 {
+    if (this == &lin_sense)
+        return *this;
+
     sigma_x_ = lin_sense.sigma_x_;
     sigma_y_ = lin_sense.sigma_y_;
     H_       = std::move(lin_sense.H_);

--- a/src/BayesFilters/src/MeasurementModel.cpp
+++ b/src/BayesFilters/src/MeasurementModel.cpp
@@ -13,10 +13,6 @@ using namespace bfl;
 using namespace Eigen;
 
 
-MeasurementModel::~MeasurementModel() noexcept
-{ }
-
-
 std::pair<bool, MatrixXd> MeasurementModel::getNoiseCovarianceMatrix() const
 {
     return std::make_pair(false, MatrixXd::Zero(1, 1));

--- a/src/BayesFilters/src/PFCorrection.cpp
+++ b/src/BayesFilters/src/PFCorrection.cpp
@@ -11,9 +11,6 @@ using namespace bfl;
 using namespace Eigen;
 
 
-PFCorrection::PFCorrection() noexcept { };
-
-
 void PFCorrection::correct(const ParticleSet& pred_particles, ParticleSet& cor_particles)
 {
     /* Perform correction if required and if measurements can be frozen. */

--- a/src/BayesFilters/src/PFCorrection.cpp
+++ b/src/BayesFilters/src/PFCorrection.cpp
@@ -21,7 +21,7 @@ void PFCorrection::correct(const ParticleSet& pred_particles, ParticleSet& cor_p
 }
 
 
-bool PFCorrection::skip(const bool status)
+bool PFCorrection::skip(const bool status) noexcept
 {
     skip_ = status;
 

--- a/src/BayesFilters/src/PFPrediction.cpp
+++ b/src/BayesFilters/src/PFPrediction.cpp
@@ -14,20 +14,6 @@ using namespace bfl;
 using namespace Eigen;
 
 
-PFPrediction::PFPrediction() noexcept { };
-
-
-PFPrediction::PFPrediction(PFPrediction&& pf_prediction) noexcept :
-    skip_prediction_(pf_prediction.skip_prediction_),
-    skip_state_(pf_prediction.skip_state_),
-    skip_exogenous_(pf_prediction.skip_exogenous_)
-{
-    pf_prediction.skip_prediction_ = false;
-    pf_prediction.skip_state_      = false;
-    pf_prediction.skip_exogenous_  = false;
-}
-
-
 void PFPrediction::predict(const ParticleSet& prev_particles, ParticleSet& pred_particles)
 {
     if (!skip_prediction_)
@@ -78,12 +64,5 @@ bool PFPrediction::getSkipExogenous()
 
 ExogenousModel& PFPrediction::getExogenousModel()
 {
-    throw std::runtime_error("ERROR::PFPREDICTION::GETEXOGENOUSMODEL\nERROR:\n\tCall to unimplemented base class method.");
-}
-
-
-void PFPrediction::setExogenousModel(std::unique_ptr<ExogenousModel> exogenous_model)
-{
-    std::cerr << "ERROR::PFPREDICTION::SETEXOGENOUSMODEL\n";
-    std::cerr << "ERROR:\n\tCall to unimplemented base class method." << std::endl;
+    throw std::runtime_error("ERROR::PFPREDICTION::GETEXOGENOUSMODEL\nERROR:\n\tObject class has no valid ExogenousModel object.");
 }

--- a/src/BayesFilters/src/PFPrediction.cpp
+++ b/src/BayesFilters/src/PFPrediction.cpp
@@ -40,12 +40,24 @@ void PFPrediction::predict(const ParticleSet& prev_particles, ParticleSet& pred_
 bool PFPrediction::skip(const std::string& what_step, const bool status)
 {
     if (what_step == "prediction")
+    {
         skip_prediction_ = status;
-    else if (what_step == "state")
+
         skip_state_ = status;
-    else if (what_step == "exogenous")
         skip_exogenous_ = status;
-    else
+    }
+    else if (what_step == "state")
+    {
+        skip_state_ = status;
+
+        skip_prediction_ = skip_state_ & skip_exogenous_;
+    }
+    else if (what_step == "exogenous")
+    {
+        skip_exogenous_ = status;
+
+        skip_prediction_ = skip_state_ & skip_exogenous_;
+    }
         return false;
 
     return true;

--- a/src/BayesFilters/src/ParticleFilter.cpp
+++ b/src/BayesFilters/src/ParticleFilter.cpp
@@ -25,10 +25,6 @@ noexcept :
 { }
 
 
-ParticleFilter::~ParticleFilter() noexcept
-{ }
-
-
 ParticleFilter::ParticleFilter(ParticleFilter&& pf) noexcept :
     initialization_(std::move(pf.initialization_)),
     prediction_(std::move(pf.prediction_)),

--- a/src/BayesFilters/src/ParticleFilter.cpp
+++ b/src/BayesFilters/src/ParticleFilter.cpp
@@ -39,6 +39,9 @@ ParticleFilter::ParticleFilter(ParticleFilter&& pf) noexcept :
 
 ParticleFilter& ParticleFilter::operator=(ParticleFilter&& pf) noexcept
 {
+    if (this == &pf)
+        return *this;
+
     initialization_ = std::move(pf.initialization_);
     prediction_     = std::move(pf.prediction_);
     correction_     = std::move(pf.correction_);

--- a/src/BayesFilters/src/ParticleSet.cpp
+++ b/src/BayesFilters/src/ParticleSet.cpp
@@ -32,10 +32,6 @@ ParticleSet::ParticleSet
 { }
 
 
-ParticleSet::~ParticleSet() noexcept
-{ }
-
-
 void ParticleSet::resize(const std::size_t components, const std::size_t dim_linear, const std::size_t dim_circular)
 {
     std::size_t new_dim = dim_linear + dim_circular * dim_circular_component;

--- a/src/BayesFilters/src/ParticleSet.cpp
+++ b/src/BayesFilters/src/ParticleSet.cpp
@@ -76,6 +76,7 @@ ParticleSet& ParticleSet::operator+=(const ParticleSet& rhs)
 ParticleSet operator+(ParticleSet lhs, const ParticleSet& rhs)
 {
     lhs += rhs;
+
     return lhs;
 }
 

--- a/src/BayesFilters/src/Resampling.cpp
+++ b/src/BayesFilters/src/Resampling.cpp
@@ -23,10 +23,6 @@ Resampling::Resampling() noexcept :
 { }
 
 
-Resampling::~Resampling() noexcept
-{ }
-
-
 Resampling::Resampling(const Resampling& resampling) noexcept :
     generator_(resampling.generator_)
 { }

--- a/src/BayesFilters/src/Resampling.cpp
+++ b/src/BayesFilters/src/Resampling.cpp
@@ -48,6 +48,9 @@ Resampling& Resampling::operator=(const Resampling& resampling)
 
 Resampling& Resampling::operator=(Resampling&& resampling) noexcept
 {
+    if (this == &resampling)
+        return *this;
+
     generator_ = std::move(resampling.generator_);
 
     return *this;
@@ -56,6 +59,9 @@ Resampling& Resampling::operator=(Resampling&& resampling) noexcept
 
 Resampling& Resampling::operator=(const Resampling&& resampling) noexcept
 {
+    if (this == &resampling)
+        return *this;
+
     generator_ = std::move(resampling.generator_);
 
     return *this;

--- a/src/BayesFilters/src/ResamplingWithPrior.cpp
+++ b/src/BayesFilters/src/ResamplingWithPrior.cpp
@@ -51,12 +51,12 @@ ResamplingWithPrior::~ResamplingWithPrior() noexcept
 
 ResamplingWithPrior& ResamplingWithPrior::operator=(ResamplingWithPrior&& resampling) noexcept
 {
-    if (this != &resampling)
-    {
-        Resampling::operator=(std::move(resampling));
+    if (this == &resampling)
+        return *this;
 
-        init_model_ = std::move(resampling.init_model_);
-    }
+    Resampling::operator=(std::move(resampling));
+
+    init_model_ = std::move(resampling.init_model_);
 
     return *this;
 }

--- a/src/BayesFilters/src/ResamplingWithPrior.cpp
+++ b/src/BayesFilters/src/ResamplingWithPrior.cpp
@@ -45,10 +45,6 @@ ResamplingWithPrior::ResamplingWithPrior(ResamplingWithPrior&& resampling) noexc
 }
 
 
-ResamplingWithPrior::~ResamplingWithPrior() noexcept
-{ }
-
-
 ResamplingWithPrior& ResamplingWithPrior::operator=(ResamplingWithPrior&& resampling) noexcept
 {
     if (this == &resampling)

--- a/src/BayesFilters/src/SIS.cpp
+++ b/src/BayesFilters/src/SIS.cpp
@@ -49,10 +49,6 @@ SIS::SIS
 { }
 
 
-SIS::~SIS() noexcept
-{ }
-
-
 SIS::SIS(SIS&& sir_pf) noexcept :
     ParticleFilter(std::move(sir_pf)),
     num_particle_(sir_pf.num_particle_),

--- a/src/BayesFilters/src/SIS.cpp
+++ b/src/BayesFilters/src/SIS.cpp
@@ -64,6 +64,9 @@ SIS::SIS(SIS&& sir_pf) noexcept :
 
 SIS& SIS::operator=(SIS&& sir_pf) noexcept
 {
+    if (this == &sir_pf)
+        return *this;
+
     ParticleFilter::operator=(std::move(sir_pf));
 
     num_particle_ = sir_pf.num_particle_;

--- a/src/BayesFilters/src/SimulatedLinearSensor.cpp
+++ b/src/BayesFilters/src/SimulatedLinearSensor.cpp
@@ -59,10 +59,6 @@ SimulatedLinearSensor::SimulatedLinearSensor(std::unique_ptr<SimulatedStateModel
 { }
 
 
-SimulatedLinearSensor::~SimulatedLinearSensor() noexcept
-{ }
-
-
 bool SimulatedLinearSensor::freeze(const Data& data)
 {
     if (!simulated_state_model_->bufferData())

--- a/src/BayesFilters/src/SimulatedStateModel.cpp
+++ b/src/BayesFilters/src/SimulatedStateModel.cpp
@@ -30,10 +30,6 @@ SimulatedStateModel::SimulatedStateModel
 }
 
 
-SimulatedStateModel::~SimulatedStateModel() noexcept
-{ }
-
-
 bool SimulatedStateModel::bufferData()
 {
     ++current_simulation_time_;

--- a/src/BayesFilters/src/UKFCorrection.cpp
+++ b/src/BayesFilters/src/UKFCorrection.cpp
@@ -49,10 +49,6 @@ UKFCorrection::UKFCorrection(UKFCorrection&& ukf_correction) noexcept :
 { }
 
 
-UKFCorrection::~UKFCorrection() noexcept
-{ }
-
-
 MeasurementModel& UKFCorrection::getMeasurementModel()
 {
     if (type_ == UKFCorrectionType::Additive)

--- a/src/BayesFilters/src/UKFPrediction.cpp
+++ b/src/BayesFilters/src/UKFPrediction.cpp
@@ -80,10 +80,6 @@ UKFPrediction::UKFPrediction(UKFPrediction&& ukf_prediction) noexcept:
 { }
 
 
-UKFPrediction::~UKFPrediction() noexcept
-{ }
-
-
 bfl::StateModel& UKFPrediction::getStateModel() noexcept
 {
     if (type_ == UKFPredictionType::Additive)

--- a/src/BayesFilters/src/UKFPrediction.cpp
+++ b/src/BayesFilters/src/UKFPrediction.cpp
@@ -102,7 +102,7 @@ void UKFPrediction::predictStep(const GaussianMixture& prev_state, GaussianMixtu
 {
     bool skip_exogenous = getSkipExogenous() || (exogenous_model_ == nullptr);
 
-    if ( getSkipState() && skip_exogenous )
+    if (getSkipState() && skip_exogenous)
     {
         /* Skip prediction step entirely. */
         pred_state = prev_state;

--- a/src/BayesFilters/src/WhiteNoiseAcceleration.cpp
+++ b/src/BayesFilters/src/WhiteNoiseAcceleration.cpp
@@ -99,6 +99,9 @@ WhiteNoiseAcceleration& WhiteNoiseAcceleration::operator=(const WhiteNoiseAccele
 
 WhiteNoiseAcceleration& WhiteNoiseAcceleration::operator=(WhiteNoiseAcceleration&& wna) noexcept
 {
+    if (this == &wna)
+        return *this;
+
     T_       = wna.T_;
     F_       = std::move(wna.F_);
     Q_       = std::move(wna.Q_);

--- a/src/BayesFilters/src/WhiteNoiseAcceleration.cpp
+++ b/src/BayesFilters/src/WhiteNoiseAcceleration.cpp
@@ -57,10 +57,6 @@ WhiteNoiseAcceleration::WhiteNoiseAcceleration() noexcept :
 { }
 
 
-WhiteNoiseAcceleration::~WhiteNoiseAcceleration() noexcept
-{ }
-
-
 WhiteNoiseAcceleration::WhiteNoiseAcceleration(const WhiteNoiseAcceleration& wna) :
     generator_(wna.generator_),
     distribution_(wna.distribution_),

--- a/test/test_SIS/main.cpp
+++ b/test/test_SIS/main.cpp
@@ -124,8 +124,7 @@ int main(int argc, char* argv[])
 
     /* Step 2.2 - Define the prediction step */
     /* Initialize the particle filter prediction step and pass the ownership of the state model. */
-    std::unique_ptr<PFPrediction> pf_prediction = utils::make_unique<DrawParticles>();
-    pf_prediction->setStateModel(std::move(wna));
+    std::unique_ptr<PFPrediction> pf_prediction = utils::make_unique<DrawParticles>(std::move(wna));
 
 
     /* Step 3 - Correction */
@@ -150,9 +149,7 @@ int main(int argc, char* argv[])
 
     /* Step 3.4 - Define the correction step */
     /* Initialize the particle filter correction step and pass the ownership of the measurement model. */
-    std::unique_ptr<PFCorrection> pf_correction = utils::make_unique<BootstrapCorrection>();
-    pf_correction->setLikelihoodModel(std::move(exp_likelihood));
-    pf_correction->setMeasurementModel(std::move(simulated_linear_sensor));
+    std::unique_ptr<PFCorrection> pf_correction = utils::make_unique<BootstrapCorrection>(std::move(simulated_linear_sensor), std::move(exp_likelihood));
 
 
     /* Step 4 - Resampling */

--- a/test/test_UPF/main.cpp
+++ b/test/test_UPF/main.cpp
@@ -195,7 +195,7 @@ int main(int argc, char* argv[])
     /* Initialize the particle filter correction step that wraps a Guassian correction step,
        in this case an unscented kalman filter correction step. */
     std::unique_ptr<GaussianCorrection> upf_correction = utils::make_unique<UKFCorrection>(std::move(simulated_linear_sensor), state_size, alpha, beta, kappa);
-    std::unique_ptr<PFCorrection> gpf_correction = utils::make_unique<GPFCorrection>(std::move(upf_correction), std::move(exp_likelihood), std::move(transition_probability_model));
+    std::unique_ptr<PFCorrection> gpf_correction = utils::make_unique<GPFCorrection>(std::move(exp_likelihood), std::move(upf_correction), std::move(transition_probability_model));
 
 
     /* Step 4 - Resampling */

--- a/test/test_UPF_MAP/main.cpp
+++ b/test/test_UPF_MAP/main.cpp
@@ -227,7 +227,7 @@ int main(int argc, char* argv[])
     /* Initialize the particle filter correction step that wraps a Guassian correction step,
        in this case an unscented kalman filter correction step. */
     std::unique_ptr<GaussianCorrection> upf_correction = utils::make_unique<UKFCorrection>(std::move(simulated_linear_sensor), state_size, alpha, beta, kappa);
-    std::unique_ptr<PFCorrection> gpf_correction = utils::make_unique<GPFCorrection>(std::move(upf_correction), std::move(exp_likelihood), std::move(transition_probability_model));
+    std::unique_ptr<PFCorrection> gpf_correction = utils::make_unique<GPFCorrection>(std::move(exp_likelihood), std::move(upf_correction), std::move(transition_probability_model));
 
 
     /* Step 4 - Resampling */


### PR DESCRIPTION
This PR is the second one incorporating commits from `claudiofantacci/bayes-filters-lib` and `xenvre/bayes-filters-lib`.

In this PR:
- Avoid self-assignment in move operators (#64)
- Make sure that the _skip_ mechanism in state models is sound (#63)
- Make sure that dtors are default for virtual dtors
- Remove some unneeded ctors
- Start API restructuring by removing setters from `*Prediction` and `*Correction` classes (#40, #44)
- General code cleanup
- Update tests accordingly
- Update `CHANGELOG.md`

Fixes #40 

Fixes #44

Fixes #63 

Fixes #64 