### PR TITLE
Restructure 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@
 - Removed setters from `*Prediction` and derived classes. All the required data to create an object are passed to the constructor.
 - Removed setters from `*Correction` and derived classes. All the required data to create an object are passed to the constructor.
 - Add `Skippable` interface class to model a functionality that can be skipped on command.
+- Add `StateProcess` interface class to describe state model functionalities.
+- Add `ExogenousProcess` interface class to describe exogenous model functionalities.
+- Add `GaussianMixturePrediction` interface class to describe Gaussian mixture-based prediction functionalities.
+- Move `ExogenousModel` inside `StateModel`. Consequently, the prediction classes only need to handle a `StateModel` that in turns will handle the `ExogenousModel` properly, if present.
 
 ##### `Filtering algorithms`
 - `SIS::filteringStep()` performs measurements freeze before performing the actual correction. The correction is skipped if the freeze fails. The user might want to re-implement this method (or provide their own algorithm) if they need to handle the measurements freeze differently.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 - Made `skip`-related variable value in `*Prediction` classes coherent with assigned values.
 - Removed setters from `*Prediction` and derived classes. All the required data to create an object are passed to the constructor.
 - Removed setters from `*Correction` and derived classes. All the required data to create an object are passed to the constructor.
+- Add `Skippable` interface class to model a functionality that can be skipped on command.
 
 ##### `Filtering algorithms`
 - `SIS::filteringStep()` performs measurements freeze before performing the actual correction. The correction is skipped if the freeze fails. The user might want to re-implement this method (or provide their own algorithm) if they need to handle the measurements freeze differently.

--- a/src/BayesFilters/CMakeLists.txt
+++ b/src/BayesFilters/CMakeLists.txt
@@ -24,8 +24,10 @@ set(${LIBRARY_TARGET_NAME}_FF_HDR
         include/BayesFilters/BootstrapCorrection.h
         include/BayesFilters/DrawParticles.h
         include/BayesFilters/ExogenousModel.h
+        include/BayesFilters/ExogenousProcess.h
         include/BayesFilters/GaussianCorrection.h
         include/BayesFilters/GaussianLikelihood.h
+        include/BayesFilters/GaussianMixturePrediction.h
         include/BayesFilters/GaussianInitialization.h
         include/BayesFilters/GaussianPrediction.h
         include/BayesFilters/GPFCorrection.h
@@ -49,6 +51,7 @@ set(${LIBRARY_TARGET_NAME}_FF_HDR
         include/BayesFilters/SimulatedStateModel.h
         include/BayesFilters/Skippable.h
         include/BayesFilters/StateModel.h
+        include/BayesFilters/StateProcess.h
         include/BayesFilters/SUKFCorrection.h
         # include/BayesFilters/TimeDecreasingDynamics.h
         include/BayesFilters/UKFCorrection.h
@@ -89,6 +92,7 @@ set(${LIBRARY_TARGET_NAME}_FF_SRC
         src/Agent.cpp
         src/BootstrapCorrection.cpp
         src/DrawParticles.cpp
+        src/ExogenousModel.cpp
         src/GaussianCorrection.cpp
         src/GaussianLikelihood.cpp
         src/GaussianPrediction.cpp

--- a/src/BayesFilters/CMakeLists.txt
+++ b/src/BayesFilters/CMakeLists.txt
@@ -47,6 +47,7 @@ set(${LIBRARY_TARGET_NAME}_FF_HDR
         include/BayesFilters/ResamplingWithPrior.h
         include/BayesFilters/SimulatedLinearSensor.h
         include/BayesFilters/SimulatedStateModel.h
+        include/BayesFilters/Skippable.h
         include/BayesFilters/StateModel.h
         include/BayesFilters/SUKFCorrection.h
         # include/BayesFilters/TimeDecreasingDynamics.h

--- a/src/BayesFilters/include/BayesFilters/AdditiveStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/AdditiveStateModel.h
@@ -8,8 +8,6 @@
 #ifndef ADDITIVESTATEMODEL_H
 #define ADDITIVESTATEMODEL_H
 
-#include <Eigen/Dense>
-
 #include <BayesFilters/StateModel.h>
 
 namespace bfl {
@@ -23,6 +21,18 @@ public:
     virtual ~AdditiveStateModel() noexcept = default;
 
     virtual void motion(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> mot_states) override;
+
+
+protected:
+    AdditiveStateModel() noexcept = default;
+
+    AdditiveStateModel(const AdditiveStateModel& state_model) noexcept = delete;
+
+    AdditiveStateModel& operator=(const AdditiveStateModel& state_model) noexcept = delete;
+
+    AdditiveStateModel(AdditiveStateModel&& state_model) noexcept = default;
+
+    AdditiveStateModel& operator=(AdditiveStateModel&& state_model) noexcept = default;
 };
 
 #endif /* ADDITIVESTATEMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/ExogenousModel.h
+++ b/src/BayesFilters/include/BayesFilters/ExogenousModel.h
@@ -8,25 +8,41 @@
 #ifndef EXOGENOUSMODEL_H
 #define EXOGENOUSMODEL_H
 
-#include <Eigen/Dense>
+#include <BayesFilters/ExogenousProcess.h>
+#include <BayesFilters/Skippable.h>
 
 namespace bfl {
     class ExogenousModel;
 }
 
 
-class bfl::ExogenousModel
+class bfl::ExogenousModel : public ExogenousProcess, public Skippable
 {
 public:
     virtual ~ExogenousModel() noexcept = default;
 
-    virtual void propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> prop_states) = 0;
+    bool skip(const std::string& what_step, const bool status) override;
 
-    virtual Eigen::MatrixXd getExogenousMatrix() = 0;
+    bool getSkipState() override;
 
-    virtual bool setProperty(const std::string& property) = 0;
 
-    virtual std::pair<std::size_t, std::size_t> getOutputSize() const = 0;
+protected:
+    ExogenousModel() noexcept = default;
+
+    ExogenousModel(const ExogenousModel& exogenous_model) noexcept = delete;
+
+    ExogenousModel& operator=(const ExogenousModel& exogenous_model) noexcept = delete;
+
+    ExogenousModel(ExogenousModel&& exogenous_model) noexcept = default;
+
+    ExogenousModel& operator=(ExogenousModel&& exogenous_model) noexcept = default;
+
+
+private:
+    /**
+     * Skip status.
+     */
+    bool skip_ = false;
 };
 
 #endif /* EXOGENOUSMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/ExogenousProcess.h
+++ b/src/BayesFilters/include/BayesFilters/ExogenousProcess.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2016-2019 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef EXOGENOUSPROCESS_H
+#define EXOGENOUSPROCESS_H
+
+#include <Eigen/Dense>
+
+namespace bfl {
+    class ExogenousProcess;
+}
+
+
+class bfl::ExogenousProcess
+{
+public:
+    virtual void propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> prop_states) = 0;
+
+    virtual bool setProperty(const std::string& property) = 0;
+
+    /**
+     * Returns the linear and circular size of the output of the state equation.
+     */
+    virtual std::pair<std::size_t, std::size_t> getOutputSize() const = 0;
+};
+
+#endif /* EXOGENOUSPROCESS_H */

--- a/src/BayesFilters/include/BayesFilters/GPFPrediction.h
+++ b/src/BayesFilters/include/BayesFilters/GPFPrediction.h
@@ -42,6 +42,8 @@ public:
 protected:
     void predictStep(const ParticleSet& previous_particles, ParticleSet& predicted_particles) override;
 
+
+private:
     std::unique_ptr<GaussianPrediction> gaussian_prediction_;
 };
 

--- a/src/BayesFilters/include/BayesFilters/GaussianMixturePrediction.h
+++ b/src/BayesFilters/include/BayesFilters/GaussianMixturePrediction.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2016-2019 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef GAUSSIANMIXTUREPREDICTION_H
+#define GAUSSIANMIXTUREPREDICTION_H
+
+#include <BayesFilters/GaussianMixture.h>
+
+#include <Eigen/Dense>
+
+namespace bfl {
+    class GaussianMixturePrediction;
+}
+
+
+class bfl::GaussianMixturePrediction
+{
+public:
+    virtual void predict(const GaussianMixture& prev_state, GaussianMixture& pred_state) = 0;
+};
+
+#endif /* GAUSSIANMIXTUREPREDICTION_H */

--- a/src/BayesFilters/include/BayesFilters/GaussianPrediction.h
+++ b/src/BayesFilters/include/BayesFilters/GaussianPrediction.h
@@ -9,7 +9,8 @@
 #define GAUSSIANPREDICTION_H
 
 #include <BayesFilters/ExogenousModel.h>
-#include <BayesFilters/GaussianMixture.h>
+#include <BayesFilters/GaussianMixturePrediction.h>
+#include <BayesFilters/Skippable.h>
 #include <BayesFilters/StateModel.h>
 
 #include <Eigen/Dense>
@@ -19,22 +20,18 @@ namespace bfl {
 }
 
 
-class bfl::GaussianPrediction
+class bfl::GaussianPrediction : public GaussianMixturePrediction, public Skippable
 {
 public:
     virtual ~GaussianPrediction() noexcept = default;
 
-    void predict(const GaussianMixture& prev_state, GaussianMixture& pred_state);
+    void predict(const GaussianMixture& prev_state, GaussianMixture& pred_state) override;
 
-    bool skip(const std::string& what_step, const bool status);
+    bool skip(const std::string& what_step, const bool status) override;
 
-    bool getSkipState();
-
-    bool getSkipExogenous();
+    bool getSkipState() override;
 
     virtual StateModel& getStateModel() noexcept = 0;
-
-    virtual ExogenousModel& getExogenousModel();
 
 
 protected:
@@ -52,11 +49,7 @@ protected:
 
 
 private:
-    bool skip_prediction_ = false;
-
-    bool skip_state_ = false;
-
-    bool skip_exogenous_ = false;
+    bool skip_ = false;
 };
 
 #endif /* GAUSSIANPREDICTION_H */

--- a/src/BayesFilters/include/BayesFilters/KFPrediction.h
+++ b/src/BayesFilters/include/BayesFilters/KFPrediction.h
@@ -25,23 +25,25 @@ class bfl::KFPrediction : public bfl::GaussianPrediction
 public:
     KFPrediction(std::unique_ptr<LinearStateModel> state_model) noexcept;
 
-    KFPrediction(std::unique_ptr<LinearStateModel> state_model, std::unique_ptr<ExogenousModel> exogenous_model) noexcept;
+    KFPrediction(const KFPrediction& prediction) noexcept = delete;
 
-    KFPrediction(KFPrediction&& kf_prediction) noexcept;
+    KFPrediction& operator=(const KFPrediction& prediction) noexcept = delete;
+
+    KFPrediction(KFPrediction&& prediction) noexcept;
+
+    KFPrediction& operator=(KFPrediction&& prediction) noexcept;
 
     virtual ~KFPrediction() noexcept = default;
 
     StateModel& getStateModel() noexcept override;
 
-    ExogenousModel& getExogenousModel() override;
-
 
 protected:
     void predictStep(const GaussianMixture& prev_state, GaussianMixture& pred_state) override;
 
-    std::unique_ptr<LinearStateModel> state_model_;
 
-    std::unique_ptr<ExogenousModel> exogenous_model_;
+private:
+    std::unique_ptr<LinearStateModel> state_model_;
 };
 
 #endif /* KFPREDICTION_H */

--- a/src/BayesFilters/include/BayesFilters/LTIStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/LTIStateModel.h
@@ -8,8 +8,6 @@
 #ifndef LTISTATEMODEL_H
 #define LTISTATEMODEL_H
 
-#include <Eigen/Dense>
-
 #include <BayesFilters/LinearStateModel.h>
 
 namespace bfl {
@@ -22,27 +20,32 @@ class bfl::LTIStateModel : public bfl::LinearStateModel
 public:
     LTIStateModel(const Eigen::Ref<const Eigen::MatrixXd>& transition_matrix, const Eigen::Ref<const Eigen::MatrixXd>& noise_covariance_matrix);
 
+    LTIStateModel(const LTIStateModel& state_model) noexcept = delete;
+
+    LTIStateModel& operator=(const LTIStateModel& state_model) noexcept = delete;
+
+    LTIStateModel(LTIStateModel&& state_model) noexcept;
+
+    LTIStateModel& operator=(LTIStateModel&& state_model) noexcept;
+
     virtual ~LTIStateModel() noexcept = default;
-
-    void propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> prop_states) override;
-
-    Eigen::MatrixXd getNoiseCovarianceMatrix() override;
-
-    Eigen::MatrixXd getStateTransitionMatrix() override;
 
     bool setProperty(const std::string& property) override;
 
     Eigen::MatrixXd getJacobian() override;
 
+    Eigen::MatrixXd getNoiseCovarianceMatrix() override;
 
-protected:
-    /*
+    Eigen::MatrixXd getStateTransitionMatrix() override;
+
+private:
+    /**
      * State transition matrix.
      */
     Eigen::MatrixXd F_;
 
-    /*
-     * Noise covariance matrix of zero mean additive white noise.
+    /**
+     * Noise covariance matrix of a zero mean additive white noise.
      */
     Eigen::MatrixXd Q_;
 };

--- a/src/BayesFilters/include/BayesFilters/LinearMeasurementModel.h
+++ b/src/BayesFilters/include/BayesFilters/LinearMeasurementModel.h
@@ -10,8 +10,6 @@
 
 #include <BayesFilters/AdditiveMeasurementModel.h>
 
-#include <Eigen/Dense>
-
 namespace bfl {
     class LinearMeasurementModel;
 }

--- a/src/BayesFilters/include/BayesFilters/LinearStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/LinearStateModel.h
@@ -8,8 +8,6 @@
 #ifndef LINEARSTATEMODEL_H
 #define LINEARSTATEMODEL_H
 
-#include <Eigen/Dense>
-
 #include <BayesFilters/AdditiveStateModel.h>
 
 namespace bfl {
@@ -22,9 +20,21 @@ class bfl::LinearStateModel : public bfl::AdditiveStateModel
 public:
     virtual ~LinearStateModel() noexcept = default;
 
-    virtual void propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> mot_states) override;
+    virtual void propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> prop_states) override;
 
     virtual Eigen::MatrixXd getStateTransitionMatrix() = 0;
+
+
+protected:
+    LinearStateModel() noexcept = default;
+
+    LinearStateModel(const LinearStateModel& state_model) noexcept = delete;
+
+    LinearStateModel& operator=(const LinearStateModel& state_model) noexcept = delete;
+
+    LinearStateModel(LinearStateModel&& state_model) noexcept = default;
+
+    LinearStateModel& operator=(LinearStateModel&& state_model) noexcept = default;
 };
 
 #endif /* LINEARSTATEMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/PFPrediction.h
+++ b/src/BayesFilters/include/BayesFilters/PFPrediction.h
@@ -13,6 +13,7 @@
 #include <BayesFilters/StateModel.h>
 
 #include <Eigen/Dense>
+
 #include <memory>
 #include <string>
 
@@ -32,11 +33,7 @@ public:
 
     bool getSkipState();
 
-    bool getSkipExogenous();
-
     virtual StateModel& getStateModel() noexcept = 0;
-
-    virtual ExogenousModel& getExogenousModel();
 
 
 protected:
@@ -54,11 +51,7 @@ protected:
 
 
 private:
-    bool skip_prediction_ = false;
-
-    bool skip_state_ = false;
-
-    bool skip_exogenous_ = false;
+    bool skip_ = false;
 };
 
 #endif /* PFPREDICTION_H */

--- a/src/BayesFilters/include/BayesFilters/Skippable.h
+++ b/src/BayesFilters/include/BayesFilters/Skippable.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2016-2019 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef SKIPPABLE_H
+#define SKIPPABLE_H
+
+#include <Eigen/Dense>
+
+namespace bfl {
+    class Skippable;
+}
+
+
+class bfl::Skippable
+{
+public:
+    virtual bool skip(const std::string& what_step, const bool status) = 0;
+
+    virtual bool getSkipState() = 0;
+};
+
+#endif /* SKIPPABLE_H */

--- a/src/BayesFilters/include/BayesFilters/StateProcess.h
+++ b/src/BayesFilters/include/BayesFilters/StateProcess.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2016-2019 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef STATEPROCESS_H
+#define STATEPROCESS_H
+
+#include <Eigen/Dense>
+
+namespace bfl {
+    class StateProcess;
+}
+
+
+class bfl::StateProcess
+{
+public:
+    virtual void propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> prop_states) = 0;
+
+    virtual void motion(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> mot_states) = 0;
+
+    virtual bool setProperty(const std::string& property) = 0;
+
+    /**
+     * Returns the linear and circular size of the output of the state equation.
+     */
+    virtual std::pair<std::size_t, std::size_t> getOutputSize() const = 0;
+};
+
+#endif /* STATEPROCESS_H */

--- a/src/BayesFilters/include/BayesFilters/UKFPrediction.h
+++ b/src/BayesFilters/include/BayesFilters/UKFPrediction.h
@@ -25,37 +25,37 @@ namespace bfl {
 class bfl::UKFPrediction : public GaussianPrediction
 {
 public:
-    UKFPrediction(std::unique_ptr<StateModel> state_model, const size_t n, const double alpha, const double beta, const double kappa) noexcept;
-
-    UKFPrediction(std::unique_ptr<StateModel> state_model, std::unique_ptr<ExogenousModel> exogenous_model, const size_t n, const double alpha, const double beta, const double kappa) noexcept;
-
-    UKFPrediction(std::unique_ptr<AdditiveStateModel> state_model, const size_t n, const double alpha, const double beta, const double kappa) noexcept;
-
-    UKFPrediction(std::unique_ptr<AdditiveStateModel> state_model, std::unique_ptr<ExogenousModel> exogenous_model, const size_t n, const double alpha, const double beta, const double kappa) noexcept;
-
-    UKFPrediction(UKFPrediction&& ukf_prediction) noexcept;
-
-    virtual ~UKFPrediction() noexcept = default;
-
-    StateModel& getStateModel() noexcept override;
-
-    ExogenousModel& getExogenousModel() override;
-
-
-protected:
-    void predictStep(const GaussianMixture& prev_state, GaussianMixture& pred_state) override;
-
-    std::unique_ptr<StateModel> state_model_;
-
-    std::unique_ptr<AdditiveStateModel> add_state_model_;
-
-    std::unique_ptr<ExogenousModel> exogenous_model_;
-
     enum class UKFPredictionType
     {
         Generic,
         Additive
     };
+
+    UKFPrediction(std::unique_ptr<StateModel> state_model, const size_t n, const double alpha, const double beta, const double kappa) noexcept;
+
+    UKFPrediction(std::unique_ptr<AdditiveStateModel> state_model, const size_t n, const double alpha, const double beta, const double kappa) noexcept;
+
+    UKFPrediction(const UKFPrediction& prediction) noexcept = delete;
+
+    UKFPrediction& operator=(const UKFPrediction& prediction) noexcept = delete;
+
+    UKFPrediction(UKFPrediction&& prediction) noexcept;
+
+    UKFPrediction& operator=(UKFPrediction&& prediction) noexcept;
+
+    virtual ~UKFPrediction() noexcept = default;
+
+    StateModel& getStateModel() noexcept override;
+
+
+protected:
+    void predictStep(const GaussianMixture& prev_state, GaussianMixture& pred_state) override;
+
+
+private:
+    std::unique_ptr<StateModel> state_model_;
+
+    std::unique_ptr<AdditiveStateModel> add_state_model_;
 
     /**
      * Distinguish between a UKFPrediction using a generic StateModel

--- a/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
+++ b/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
@@ -21,21 +21,25 @@ namespace bfl {
 class bfl::WhiteNoiseAcceleration : public LinearStateModel
 {
 public:
-    WhiteNoiseAcceleration(double T, double tilde_q, unsigned int seed) noexcept;
+    WhiteNoiseAcceleration() noexcept;
 
     WhiteNoiseAcceleration(double T, double tilde_q) noexcept;
 
-    WhiteNoiseAcceleration() noexcept;
+    WhiteNoiseAcceleration(double T, double tilde_q, unsigned int seed) noexcept;
 
-    WhiteNoiseAcceleration(const WhiteNoiseAcceleration& wna);
+    WhiteNoiseAcceleration(const WhiteNoiseAcceleration& state_model) noexcept = delete;
 
-    WhiteNoiseAcceleration(WhiteNoiseAcceleration&& wna) noexcept;
+    WhiteNoiseAcceleration& operator=(const WhiteNoiseAcceleration& state_model) noexcept = delete;
+
+    WhiteNoiseAcceleration(WhiteNoiseAcceleration&& state_model) noexcept;
+
+    WhiteNoiseAcceleration& operator=(WhiteNoiseAcceleration&& state_model) noexcept;
 
     virtual ~WhiteNoiseAcceleration() noexcept = default;
 
-    WhiteNoiseAcceleration& operator=(const WhiteNoiseAcceleration& wna);
+    bool setProperty(const std::string& property) override;
 
-    WhiteNoiseAcceleration& operator=(WhiteNoiseAcceleration&& wna) noexcept;
+    std::pair<std::size_t, std::size_t> getOutputSize() const override;
 
     Eigen::MatrixXd getNoiseSample(const std::size_t num) override;
 
@@ -44,10 +48,6 @@ public:
     Eigen::MatrixXd getStateTransitionMatrix() override;
 
     Eigen::VectorXd getTransitionProbability(const Eigen::Ref<const Eigen::MatrixXd>& prev_states, const Eigen::Ref<const Eigen::MatrixXd>& cur_states) override;
-
-    bool setProperty(const std::string& property) override { return false; };
-
-    std::pair<std::size_t, std::size_t> getOutputSize() const override;
 
 
 private:

--- a/src/BayesFilters/include/BayesFilters/sigma_point.h
+++ b/src/BayesFilters/include/BayesFilters/sigma_point.h
@@ -32,12 +32,15 @@ namespace sigma_point
      * - the output size as a pair of std::size_t indicating linear and circular size
      */
     using OutputSize = std::pair<std::size_t, std::size_t>;
+
     using FunctionEvaluation = std::function<std::tuple<bool, bfl::Data, OutputSize>(const Eigen::Ref<const Eigen::MatrixXd>&)>;
 
     struct UTWeight
     {
         Eigen::VectorXd mean;
+
         Eigen::VectorXd covariance;
+
         /**
          * c = sqrt(n + lambda) with lambda a ut parameter.
          */
@@ -54,13 +57,7 @@ namespace sigma_point
 
     std::pair<GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, StateModel& state_model);
 
-    std::pair<GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, StateModel& state_model, ExogenousModel& exogenous_model);
-
     std::pair<GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, AdditiveStateModel& state_model);
-
-    std::pair<GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, AdditiveStateModel& state_model, ExogenousModel& exogenous_model);
-
-    std::pair<GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, ExogenousModel& exogenous_model);
 
     std::tuple<bool, GaussianMixture, Eigen::MatrixXd> unscented_transform(const GaussianMixture& state, const UTWeight& weight, MeasurementModel& meas_model);
 

--- a/src/BayesFilters/src/AdditiveStateModel.cpp
+++ b/src/BayesFilters/src/AdditiveStateModel.cpp
@@ -7,12 +7,11 @@
 
 #include <BayesFilters/AdditiveStateModel.h>
 
-#include <Eigen/Dense>
-
 using namespace bfl;
 using namespace Eigen;
 
-void AdditiveStateModel::motion(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> mot_states)
+
+void AdditiveStateModel::motion(const Ref<const MatrixXd>& cur_states, Ref<MatrixXd> mot_states)
 {
     propagate(cur_states, mot_states);
 

--- a/src/BayesFilters/src/ExogenousModel.cpp
+++ b/src/BayesFilters/src/ExogenousModel.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2016-2019 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <BayesFilters/ExogenousModel.h>
+
+using namespace bfl;
+using namespace Eigen;
+
+
+bool ExogenousModel::skip(const std::string& what_step, const bool status)
+{
+    if (what_step == "exogenous")
+        skip_ = status;
+    else
+        return false;
+
+    return true;
+}
+
+
+bool ExogenousModel::getSkipState()
+{
+    return skip_;
+}

--- a/src/BayesFilters/src/GPFPrediction.cpp
+++ b/src/BayesFilters/src/GPFPrediction.cpp
@@ -26,6 +26,9 @@ GPFPrediction::GPFPrediction(GPFPrediction&& prediction) noexcept :
 
 GPFPrediction& GPFPrediction::operator=(GPFPrediction&& prediction) noexcept
 {
+    if (this == &prediction)
+        return *this;
+
     PFPrediction::operator=(std::move(prediction));
 
     gaussian_prediction_ = std::move(prediction.gaussian_prediction_);
@@ -42,10 +45,6 @@ StateModel& GPFPrediction::getStateModel() noexcept
 
 void GPFPrediction::predictStep(const ParticleSet& prev_particles, ParticleSet& pred_particles)
 {
-    /* Set skip flags within the Gaussian prediction. */
-    gaussian_prediction_->skip("state", getSkipState());
-    gaussian_prediction_->skip("exogenous", getSkipExogenous());
-
     /* Propagate Gaussian belief associated to each particle. */
     gaussian_prediction_->predict(prev_particles, pred_particles);
 

--- a/src/BayesFilters/src/GaussianPrediction.cpp
+++ b/src/BayesFilters/src/GaussianPrediction.cpp
@@ -17,7 +17,7 @@ using namespace Eigen;
 
 void GaussianPrediction::predict(const GaussianMixture& prev_state, GaussianMixture& pred_state)
 {
-    if (!skip_prediction_)
+    if (!skip_)
         predictStep(prev_state, pred_state);
     else
         pred_state = prev_state;
@@ -28,22 +28,23 @@ bool GaussianPrediction::skip(const std::string& what_step, const bool status)
 {
     if (what_step == "prediction")
     {
-        skip_prediction_ = status;
+        skip_ = status;
 
-        skip_state_ = status;
-        skip_exogenous_ = status;
+        getStateModel().skip("state", status);
+
+        getStateModel().skip("exogenous", status);
     }
     else if (what_step == "state")
     {
-        skip_state_ = status;
+        getStateModel().skip("state", status);
 
-        skip_prediction_ = skip_state_ & skip_exogenous_;
+        skip_ = getStateModel().getSkipState() & getStateModel().exogenous_model().getSkipState();
     }
     else if (what_step == "exogenous")
     {
-        skip_exogenous_ = status;
+        getStateModel().skip("exogenous", status);
 
-        skip_prediction_ = skip_state_ & skip_exogenous_;
+        skip_ = getStateModel().getSkipState() & getStateModel().exogenous_model().getSkipState();
     }
     else
         return false;
@@ -54,17 +55,5 @@ bool GaussianPrediction::skip(const std::string& what_step, const bool status)
 
 bool GaussianPrediction::getSkipState()
 {
-    return skip_state_;
-}
-
-
-bool GaussianPrediction::getSkipExogenous()
-{
-    return skip_exogenous_;
-}
-
-
-ExogenousModel& GaussianPrediction::getExogenousModel()
-{
-    throw std::runtime_error("ERROR::GAUSSIANPREDICTION::GETEXOGENOUSMODEL\nERROR:\n\tCall to unimplemented base class method.");
+    return skip_;
 }

--- a/src/BayesFilters/src/KFPrediction.cpp
+++ b/src/BayesFilters/src/KFPrediction.cpp
@@ -16,16 +16,23 @@ KFPrediction::KFPrediction(std::unique_ptr<LinearStateModel> state_model) noexce
 { }
 
 
-KFPrediction::KFPrediction(std::unique_ptr<LinearStateModel> state_model, std::unique_ptr<ExogenousModel> exogenous_model) noexcept :
-    state_model_(std::move(state_model)),
-    exogenous_model_(std::move(exogenous_model))
+KFPrediction::KFPrediction(KFPrediction&& prediction) noexcept:
+    GaussianPrediction(std::move(prediction)),
+    state_model_(std::move(prediction.state_model_))
 { }
 
 
-KFPrediction::KFPrediction(KFPrediction&& kf_prediction) noexcept:
-    state_model_(std::move(kf_prediction.state_model_)),
-    exogenous_model_(std::move(kf_prediction.exogenous_model_))
-{ }
+KFPrediction& KFPrediction::operator=(KFPrediction&& prediction) noexcept
+{
+    if (this == &prediction)
+        return *this;
+
+    GaussianPrediction::operator=(std::move(prediction));
+
+    state_model_ = std::move(prediction.state_model_);
+
+    return *this;
+}
 
 
 bfl::StateModel& KFPrediction::getStateModel() noexcept
@@ -34,57 +41,23 @@ bfl::StateModel& KFPrediction::getStateModel() noexcept
 }
 
 
-bfl::ExogenousModel& KFPrediction::getExogenousModel()
-{
-    if (exogenous_model_ == nullptr)
-        throw std::runtime_error("ERROR::KFPREDICTION::GETEXOGENOUSMODEL\nERROR:\n\tExogenous model does not exist. Did you pass it to KFPrediction ctor?");
-
-    return *exogenous_model_;
-}
-
-
 void KFPrediction::predictStep(const GaussianMixture& prev_state, GaussianMixture& pred_state)
 {
-    bool skip_exogenous = getSkipExogenous() || (exogenous_model_ == nullptr);
-
-    if (getSkipState() && skip_exogenous)
+    if (getStateModel().getSkipState())
     {
-        /* Skip prediction step entirely. */
         pred_state = prev_state;
+
         return;
     }
 
-    if (!getSkipState())
-    {
-        /* Evaluate predicted mean
-           x_{k+1} = F_{k} x_{k}   */
-        MatrixXd F = state_model_->getStateTransitionMatrix();
-        pred_state.mean().noalias() = F * prev_state.mean();
+    /* Evaluate predicted mean
+       x_{k+1} = F_{k} x_{k}   */
+    getStateModel().propagate(prev_state.mean(), pred_state.mean());
 
-        /* Evaluate predicted covariance.
-           P_{k+1} = F_{k} * P_{k} * F_{k}' + Q */
-        for (size_t i=0; i < prev_state.components; i++)
-            pred_state.covariance(i).noalias() = F * prev_state.covariance(i) * F.transpose() + state_model_->getNoiseCovarianceMatrix();
+    /* Evaluate predicted covariance.
+       P_{k+1} = F_{k} * P_{k} * F_{k}' + Q */
+    MatrixXd F = state_model_->getStateTransitionMatrix();
 
-        if (!skip_exogenous)
-        {
-            /* Since it is not clear whether ExogenousModel::propagate takes
-               into account aliasing or not, then a temporary is used here. */
-            MatrixXd tmp(pred_state.mean().rows(), pred_state.mean().cols());
-
-            exogenous_model_->propagate(pred_state.mean(), tmp);
-
-            pred_state.mean() = std::move(tmp);
-        }
-    }
-    else
-    {
-        /* Assuming that also the uncertainty due to the noise is neglected if (getSkipState == true). */
-        pred_state.covariance() = prev_state.covariance();
-
-        if (!skip_exogenous)
-        {
-            exogenous_model_->propagate(prev_state.mean(), pred_state.mean());
-        }
-    }
+    for (size_t i=0; i < prev_state.components; i++)
+        pred_state.covariance(i).noalias() = F * prev_state.covariance(i) * F.transpose() + state_model_->getNoiseCovarianceMatrix();
 }

--- a/src/BayesFilters/src/LTIStateModel.cpp
+++ b/src/BayesFilters/src/LTIStateModel.cpp
@@ -7,8 +7,6 @@
 
 #include <BayesFilters/LTIStateModel.h>
 
-#include <Eigen/Dense>
-
 using namespace bfl;
 using namespace Eigen;
 
@@ -30,21 +28,22 @@ LTIStateModel::LTIStateModel(const Ref<const MatrixXd>& transition_matrix, const
 }
 
 
-void LTIStateModel::propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> prop_states)
+LTIStateModel::LTIStateModel(LTIStateModel&& state_model) noexcept :
+    F_(std::move(state_model.F_)),
+    Q_(std::move(state_model.Q_))
+{ }
+
+
+LTIStateModel& LTIStateModel::operator=(LTIStateModel&& state_model) noexcept
 {
-    prop_states = F_ * cur_states;
-}
+    if (this == &state_model)
+        return *this;
 
+    F_ = std::move(state_model.F_);
 
-Eigen::MatrixXd LTIStateModel::getNoiseCovarianceMatrix()
-{
-    return Q_;
-}
+    Q_ = std::move(state_model.Q_);
 
-
-Eigen::MatrixXd LTIStateModel::getStateTransitionMatrix()
-{
-    return F_;
+    return *this;
 }
 
 
@@ -54,7 +53,19 @@ bool LTIStateModel::setProperty(const std::string& property)
 }
 
 
-Eigen::MatrixXd LTIStateModel::getJacobian()
+MatrixXd LTIStateModel::getNoiseCovarianceMatrix()
+{
+    return Q_;
+}
+
+
+MatrixXd LTIStateModel::getStateTransitionMatrix()
+{
+    return F_;
+}
+
+
+MatrixXd LTIStateModel::getJacobian()
 {
     return F_;
 }

--- a/src/BayesFilters/src/PFPrediction.cpp
+++ b/src/BayesFilters/src/PFPrediction.cpp
@@ -16,7 +16,7 @@ using namespace Eigen;
 
 void PFPrediction::predict(const ParticleSet& prev_particles, ParticleSet& pred_particles)
 {
-    if (!skip_prediction_)
+    if (!skip_)
         predictStep(prev_particles, pred_particles);
     else
         pred_particles = prev_particles;
@@ -27,23 +27,25 @@ bool PFPrediction::skip(const std::string& what_step, const bool status)
 {
     if (what_step == "prediction")
     {
-        skip_prediction_ = status;
+        skip_ = status;
 
-        skip_state_ = status;
-        skip_exogenous_ = status;
+        getStateModel().skip("state", status);
+
+        getStateModel().skip("exogenous", status);
     }
     else if (what_step == "state")
     {
-        skip_state_ = status;
+        getStateModel().skip("state", status);
 
-        skip_prediction_ = skip_state_ & skip_exogenous_;
+        skip_ = getStateModel().getSkipState() & getStateModel().exogenous_model().getSkipState();
     }
     else if (what_step == "exogenous")
     {
-        skip_exogenous_ = status;
+        getStateModel().skip("exogenous", status);
 
-        skip_prediction_ = skip_state_ & skip_exogenous_;
+        skip_ = getStateModel().getSkipState() & getStateModel().exogenous_model().getSkipState();
     }
+    else
         return false;
 
     return true;
@@ -52,17 +54,5 @@ bool PFPrediction::skip(const std::string& what_step, const bool status)
 
 bool PFPrediction::getSkipState()
 {
-    return skip_state_;
-}
-
-
-bool PFPrediction::getSkipExogenous()
-{
-    return skip_exogenous_;
-}
-
-
-ExogenousModel& PFPrediction::getExogenousModel()
-{
-    throw std::runtime_error("ERROR::PFPREDICTION::GETEXOGENOUSMODEL\nERROR:\n\tObject class has no valid ExogenousModel object.");
+    return skip_;
 }

--- a/src/BayesFilters/src/StateModel.cpp
+++ b/src/BayesFilters/src/StateModel.cpp
@@ -11,6 +11,52 @@ using namespace bfl;
 using namespace Eigen;
 
 
+bool StateModel::skip(const std::string& what_step, const bool status)
+{
+    if (what_step == "state")
+        skip_ = status;
+    else if (what_step == "exogenous")
+        exogenous_model().skip(what_step, status);
+    else
+        return false;
+
+    return true;
+}
+
+
+bool StateModel::getSkipState()
+{
+    return skip_;
+}
+
+
+bool StateModel::add_exogenous_model(std::unique_ptr<ExogenousModel> exogenous_model)
+{
+    exogenous_model_ = std::move(exogenous_model);
+
+    return true;
+}
+
+
+bool StateModel::have_exogenous_model() noexcept
+{
+    if (exogenous_model_)
+        return true;
+    else
+        return false;
+}
+
+
+ExogenousModel& StateModel::exogenous_model()
+{
+    if (exogenous_model_)
+        return *exogenous_model_;
+
+    throw std::runtime_error("ERROR::LTISTATEMODEL::GET_EXOGENOUS_MODEL\nERROR:\n\tNo valid ExogenousModel object present in LTIStateModel object. Use LTIStateModel::add_exogenous_model() to add one.");
+}
+
+
+
 Eigen::MatrixXd StateModel::getJacobian()
 {
     throw std::runtime_error("ERROR::STATEMODEL::GETJACOBIAN\nERROR:\n\tMethod not implemented.");


### PR DESCRIPTION
This PR is the third of a series incorporating commits from `claudiofantacci/bayes-filters-lib` and `xenvre/bayes-filters-lib`.

In this PR:

### New interfaces

- Add `Skippable` interface modelling a functionality that can be skipped when needed
- Add `StateProcess` interface class to describe state model functionalities (e.g. state prediction, state motion)
- Add `ExogenousProcess` interface class to describe exogenous model functionalities (e.g. external inputs, external sensors)
- Add `GaussianMixturePrediction` interface class to describe Gaussian mixture-based prediction functionalities.
- Add `ParticleSetPrediction` interface

### Use of new interfaces in existing classes

- `ExogenousModel` inherits from `ExogenousProcess` and `Skippable`
- `GaussianPrediction` inherits from `GaussianMixturePrediction` and `Skippable`
- `StateModel` inherits from `StateProcess` and `Skippable`
- `StateModel` implements methods `add_exogenous_model`, `have_exogenous_model` and `exogenous_model`
> newly introduced method starts adopting snake case convention (this will be finalized in next PRs)

### `Exogenous model` moves inside `StateModel` and related

- Move `ExogenousModel` inside `StateModel`
- `KFPrediction` does not accept exogenous models at construction time anymore
- `UKFPrediction` does not accept exogenous models at construction time anymore
- `unscented_transform` utilities in `sigma_point.h` do  not handle exogenous models anymore
- Simplify implementation of 
   - `KFPrediction::predictStep`
- Revise implementation of
   - `PFPrediction::skip`
   - `GFPrediction::skip`
   - `LinearStateModel::propagate`
   - `PFPrediction::predict`

### Misc.
- Delete copy constructor/assignment and add default move constructor/assignment in classes
  - `AdditiveStateModel`
  - `ExogenousModel`
  - `KFPrediction`
  - `LTIStateModel`
  - `LinearStateModel`
  - `UKFPrediction`
  - `WhiteNoiseAcceleration`

Fixes #68