### PR TITLE
Restructure 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@
 - Added method `bfl::utils::diff_quaternion()` that evaluates the colwise difference between a set of quaternions and a given unitary quaternion (right operand). The i-th difference is obtained as the logarithm of the quaternion product between the i-th quaternion and the conjugated right operand, i.e it is a rotation vector.
 - Added method `bfl::utils::mean_quaternion()` that evaluates the weighted mean of a set of unitary quaternions.
 - utils.h is now a template header-only utility file.
+- Add `Skipper` interface class to model skipping functionalities.
+- Add `Skippable` interface class to model a functionality that can be skipped on command.
+- Rename `Skippable::getSkipState()` in `Skippable::is_skipping()`.
 
 ##### `Filtering functions`
 - Added pure public virtual method GaussianPrediction::getStateModel() (required to properly implement GPFPrediction::getStateModel()).
@@ -66,7 +69,6 @@
 - Made `skip`-related variable value in `*Prediction` classes coherent with assigned values.
 - Removed setters from `*Prediction` and derived classes. All the required data to create an object are passed to the constructor.
 - Removed setters from `*Correction` and derived classes. All the required data to create an object are passed to the constructor.
-- Add `Skippable` interface class to model a functionality that can be skipped on command.
 - Add `StateProcess` interface class to describe state model functionalities.
 - Add `ExogenousProcess` interface class to describe exogenous model functionalities.
 - Add `GaussianMixturePrediction` interface class to describe Gaussian mixture-based prediction functionalities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,9 +80,17 @@
 - Rename `FilteringAlgorithm::initialization()` in `FilteringAlgorithm::initialization_step()`.
 - Rename `FilteringAlgorithm::filteringStep()` in `FilteringAlgorithm::filtering_step()`.
 - Rename `FilteringAlgorithm::runCondition()` in `FilteringAlgorithm::run_condition()`.
+- Method `PFCorrection::freeze_measurements()` takes an input argument of type `Data`.
+- Method `GaussianCorrection::freeze_measurements()` takes an input argument of type `Data` such that it can be passed to the underlying `MeasurementModel::freeze(const bfl::Data&)`.
 
 ##### `Filtering algorithms`
 - `SIS::filteringStep()` performs measurements freeze before performing the actual correction. The correction is skipped if the freeze fails. The user might want to re-implement this method (or provide their own algorithm) if they need to handle the measurements freeze differently.
+- Add method `GaussianFilter::prediction()` returning reference to the underlying `GaussianPrediction` `prediction_` (now private).
+- Add method `GaussianFilter::correction()` returning reference to the underlying `GaussianCorrection` `correction_` (now private).
+- Add method `ParticleFilter::initialization()` returning reference to the underlying `ParticleSetInitialization` `initialization_`.
+- Add method `ParticleFilter::prediction()` returning reference to the underlying `PFPrediction` `prediction_` (now private).
+- Add method `ParticleFilter::correction()` returning reference to the underlying `PFCorrection``correction_` (now private).
+- Add method `ParticleFilter::resampling()` returning reference to the underlying `Resampling` `resampling_`.
 
 ##### `Test`
 - Mean extraction is performed using EstimatesExtraction utilities in test_UPF.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,13 @@
 - Add `ExogenousProcess` interface class to describe exogenous model functionalities.
 - Add `GaussianMixturePrediction` interface class to describe Gaussian mixture-based prediction functionalities.
 - Move `ExogenousModel` inside `StateModel`. Consequently, the prediction classes only need to handle a `StateModel` that in turns will handle the `ExogenousModel` properly, if present.
+- Add `Filter` interface class to describe Bayes filter functionalities.
+- Rename `FilteringAlgorithm::getFilteringStep()` in `FilteringAlgorithm::step_number()`.
+- Rename `FilteringAlgorithm::isRunning()` in `FilteringAlgorithm::is_running()`.
+- Rename `FilteringAlgorithm::filteringRecursion()` in `FilteringAlgorithm::filtering_recursion()`.
+- Rename `FilteringAlgorithm::initialization()` in `FilteringAlgorithm::initialization_step()`.
+- Rename `FilteringAlgorithm::filteringStep()` in `FilteringAlgorithm::filtering_step()`.
+- Rename `FilteringAlgorithm::runCondition()` in `FilteringAlgorithm::run_condition()`.
 
 ##### `Filtering algorithms`
 - `SIS::filteringStep()` performs measurements freeze before performing the actual correction. The correction is skipped if the freeze fails. The user might want to re-implement this method (or provide their own algorithm) if they need to handle the measurements freeze differently.

--- a/src/BayesFilters/CMakeLists.txt
+++ b/src/BayesFilters/CMakeLists.txt
@@ -49,6 +49,7 @@ set(${LIBRARY_TARGET_NAME}_FF_HDR
         include/BayesFilters/ResamplingWithPrior.h
         include/BayesFilters/SimulatedLinearSensor.h
         include/BayesFilters/SimulatedStateModel.h
+        include/BayesFilters/Skipper.h
         include/BayesFilters/Skippable.h
         include/BayesFilters/StateModel.h
         include/BayesFilters/StateProcess.h

--- a/src/BayesFilters/CMakeLists.txt
+++ b/src/BayesFilters/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_TARGET_NAME BayesFilters)
 
 # List of library header files
 set(${LIBRARY_TARGET_NAME}_FA_HDR
+        include/BayesFilters/Filter.h
         include/BayesFilters/FilteringAlgorithm.h
         include/BayesFilters/GaussianFilter.h
         include/BayesFilters/ParticleFilter.h

--- a/src/BayesFilters/include/BayesFilters/ExogenousModel.h
+++ b/src/BayesFilters/include/BayesFilters/ExogenousModel.h
@@ -23,7 +23,7 @@ public:
 
     bool skip(const std::string& what_step, const bool status) override;
 
-    bool getSkipState() override;
+    bool is_skipping() override;
 
 
 protected:

--- a/src/BayesFilters/include/BayesFilters/Filter.h
+++ b/src/BayesFilters/include/BayesFilters/Filter.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016-2019 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef FILTER_H
+#define FILTER_H
+
+namespace bfl {
+    class Filter;
+}
+
+
+class bfl::Filter
+{
+public:
+    virtual bool boot() = 0;
+
+    virtual void run() = 0;
+
+    virtual bool wait() = 0;
+
+    virtual void reset() = 0;
+
+    virtual void reboot() = 0;
+
+    virtual bool teardown() = 0;
+
+    virtual unsigned int step_number() = 0;
+
+    virtual bool is_running() = 0;
+};
+
+#endif /* FILTER_H */

--- a/src/BayesFilters/include/BayesFilters/FilteringAlgorithm.h
+++ b/src/BayesFilters/include/BayesFilters/FilteringAlgorithm.h
@@ -8,7 +8,9 @@
 #ifndef FILTERINGALGORITHM_H
 #define FILTERINGALGORITHM_H
 
+#include <BayesFilters/Filter.h>
 #include <BayesFilters/Logger.h>
+#include <BayesFilters/Skipper.h>
 
 #include <condition_variable>
 #include <mutex>
@@ -26,44 +28,52 @@ namespace bfl {
 }
 
 
-class bfl::FilteringAlgorithm : public Logger
+class bfl::FilteringAlgorithm : public Filter, public Skipper, public Logger
 {
 public:
     virtual ~FilteringAlgorithm() noexcept = default;
 
-    bool boot();
+    bool boot() override;
 
-    void run();
+    void run() override;
 
-    bool wait();
+    bool wait() override;
 
-    void reset();
+    void reset() override;
 
-    void reboot();
+    void reboot() override;
 
-    bool teardown();
+    bool teardown() override;
 
-    unsigned int getFilteringStep();
+    unsigned int step_number() override;
 
-    bool isRunning();
-
-    virtual bool skip(const std::string& what_step, const bool status) = 0;
+    bool is_running() override;
 
 
 protected:
-    virtual bool initialization() = 0;
+    FilteringAlgorithm() = default;
 
-    virtual void filteringStep() = 0;
+    FilteringAlgorithm(const FilteringAlgorithm& filter) noexcept = delete;
 
-    virtual bool runCondition() = 0;
+    FilteringAlgorithm& operator=(const FilteringAlgorithm& filter) noexcept = delete;
+
+    FilteringAlgorithm(FilteringAlgorithm&& filter) noexcept = delete;
+
+    FilteringAlgorithm& operator=(FilteringAlgorithm&& filter) noexcept = delete;
+
+    virtual bool initialization_step() = 0;
+
+    virtual void filtering_step() = 0;
+
+    virtual bool run_condition() = 0;
 
 
 private:
+    void filtering_recursion();
+
     unsigned int filtering_step_ = 0;
 
     std::thread filtering_thread_;
-
-    void filteringRecursion();
 
     std::mutex mtx_run_;
 

--- a/src/BayesFilters/include/BayesFilters/GaussianCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/GaussianCorrection.h
@@ -29,7 +29,7 @@ public:
 
     virtual MeasurementModel& getMeasurementModel() = 0;
 
-    bool freeze_measurements();
+    bool freeze_measurements(const Data& data = Data());
 
     virtual std::pair<bool, Eigen::VectorXd> getLikelihood();
 

--- a/src/BayesFilters/include/BayesFilters/GaussianFilter.h
+++ b/src/BayesFilters/include/BayesFilters/GaussianFilter.h
@@ -21,18 +21,28 @@ namespace bfl {
 class bfl::GaussianFilter : public bfl::FilteringAlgorithm
 {
 public:
-    GaussianFilter(std::unique_ptr<GaussianPrediction> prediction, std::unique_ptr<GaussianCorrection> correction) noexcept;
-
-    GaussianFilter(GaussianFilter&& kf) noexcept;
-
-    GaussianFilter& operator=(GaussianFilter&& gf) noexcept;
-
     virtual ~GaussianFilter() noexcept = default;
 
     bool skip(const std::string& what_step, const bool status) override;
 
 
 protected:
+    GaussianFilter(std::unique_ptr<GaussianPrediction> prediction, std::unique_ptr<GaussianCorrection> correction) noexcept;
+
+    GaussianFilter(const GaussianFilter& filter) noexcept = delete;
+
+    GaussianFilter& operator=(const GaussianFilter& filter) noexcept = delete;
+
+    GaussianFilter(GaussianFilter&& filter) noexcept = delete;
+
+    GaussianFilter& operator=(GaussianFilter&& filter) noexcept = delete;
+
+    GaussianPrediction& prediction();
+
+    GaussianCorrection& correction();
+
+
+private:
     std::unique_ptr<GaussianPrediction> prediction_;
 
     std::unique_ptr<GaussianCorrection> correction_;

--- a/src/BayesFilters/include/BayesFilters/GaussianPrediction.h
+++ b/src/BayesFilters/include/BayesFilters/GaussianPrediction.h
@@ -29,7 +29,7 @@ public:
 
     bool skip(const std::string& what_step, const bool status) override;
 
-    bool getSkipState() override;
+    bool is_skipping() override;
 
     virtual StateModel& getStateModel() noexcept = 0;
 

--- a/src/BayesFilters/include/BayesFilters/PFCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/PFCorrection.h
@@ -31,7 +31,7 @@ public:
 
     bool skip(const bool status) noexcept;
 
-    bool freeze_measurements();
+    bool freeze_measurements(const Data& data = Data());
 
     virtual MeasurementModel& getMeasurementModel() noexcept = 0;
 

--- a/src/BayesFilters/include/BayesFilters/PFPrediction.h
+++ b/src/BayesFilters/include/BayesFilters/PFPrediction.h
@@ -31,7 +31,7 @@ public:
 
     bool skip(const std::string& what_step, const bool status);
 
-    bool getSkipState();
+    bool is_skipping();
 
     virtual StateModel& getStateModel() noexcept = 0;
 

--- a/src/BayesFilters/include/BayesFilters/ParticleFilter.h
+++ b/src/BayesFilters/include/BayesFilters/ParticleFilter.h
@@ -24,17 +24,32 @@ namespace bfl{
 class bfl::ParticleFilter : public FilteringAlgorithm
 {
 public:
-    virtual bool skip(const std::string& what_step, const bool status) override;
-
     virtual ~ParticleFilter() noexcept = default;
+
+    bool skip(const std::string& what_step, const bool status) override;
 
 
 protected:
     ParticleFilter(std::unique_ptr<ParticleSetInitialization> initialization, std::unique_ptr<PFPrediction> prediction, std::unique_ptr<PFCorrection> correction, std::unique_ptr<Resampling> resampling) noexcept;
 
-    ParticleFilter(ParticleFilter&& pf) noexcept;
+    ParticleFilter(const ParticleFilter& filter) noexcept = delete;
 
-    ParticleFilter& operator=(ParticleFilter&& pf) noexcept;
+    ParticleFilter& operator=(const ParticleFilter& filter) noexcept = delete;
+
+    ParticleFilter(ParticleFilter&& filter) noexcept = delete;
+
+    ParticleFilter& operator=(ParticleFilter&& filter) noexcept = delete;
+
+    ParticleSetInitialization& initialization();
+
+    PFPrediction& prediction();
+
+    PFCorrection& correction();
+
+    Resampling& resampling();
+
+
+private:
 
     std::unique_ptr<ParticleSetInitialization> initialization_;
 

--- a/src/BayesFilters/include/BayesFilters/SIS.h
+++ b/src/BayesFilters/include/BayesFilters/SIS.h
@@ -17,8 +17,6 @@
 #include <fstream>
 #include <memory>
 
-#include <Eigen/Dense>
-
 namespace bfl {
     class SIS;
 }
@@ -31,14 +29,28 @@ public:
 
     SIS(unsigned int num_particle, std::size_t state_size_linear, std::unique_ptr<ParticleSetInitialization> initialization, std::unique_ptr<PFPrediction> prediction, std::unique_ptr<PFCorrection> correction, std::unique_ptr<Resampling> resampling) noexcept;
 
-    SIS(SIS&& sir_pf) noexcept;
+    SIS(const SIS& filter) noexcept = delete;
+
+    SIS& operator=(const SIS& filter) noexcept = delete;
+
+    SIS(SIS&& filter) noexcept = delete;
+
+    SIS& operator=(SIS&& filter) noexcept = delete;
 
     virtual ~SIS() noexcept = default;
 
-    SIS& operator=(SIS&& sir_pf) noexcept;
-
 
 protected:
+    bool initialization_step() override;
+
+    void filtering_step() override;
+
+    bool run_condition() override;
+
+    std::vector<std::string> log_file_names(const std::string& folder_path, const std::string& file_name_prefix) override;
+
+    void log() override;
+
     unsigned int num_particle_;
 
     std::size_t state_size_;
@@ -46,22 +58,6 @@ protected:
     ParticleSet pred_particle_;
 
     ParticleSet cor_particle_;
-
-    bool initialization() override;
-
-    void filteringStep() override;
-
-    bool runCondition() override;
-
-    std::vector<std::string> log_file_names(const std::string& folder_path, const std::string& file_name_prefix) override
-    {
-        return {folder_path + "/" + file_name_prefix + "_pred_particles",
-                folder_path + "/" + file_name_prefix + "_pred_weights",
-                folder_path + "/" + file_name_prefix + "_cor_particles",
-                folder_path + "/" + file_name_prefix + "_cor_weights"};
-    }
-
-    void log() override;
 };
 
 #endif /* SIS_H */

--- a/src/BayesFilters/include/BayesFilters/Skipper.h
+++ b/src/BayesFilters/include/BayesFilters/Skipper.h
@@ -5,20 +5,20 @@
  * BSD 3-Clause license. See the accompanying LICENSE file for details.
  */
 
-#ifndef SKIPPABLE_H
-#define SKIPPABLE_H
+#ifndef SKIPPER_H
+#define SKIPPER_H
 
-#include <BayesFilters/Skipper.h>
+#include <string>
 
 namespace bfl {
-    class Skippable;
+    class Skipper;
 }
 
 
-class bfl::Skippable : public Skipper
+class bfl::Skipper
 {
 public:
-    virtual bool is_skipping() = 0;
+    virtual bool skip(const std::string& what_step, const bool status) = 0;
 };
 
-#endif /* SKIPPABLE_H */
+#endif /* SKIPPER_H */

--- a/src/BayesFilters/include/BayesFilters/StateModel.h
+++ b/src/BayesFilters/include/BayesFilters/StateModel.h
@@ -26,7 +26,7 @@ public:
 
     bool skip(const std::string& what_step, const bool status) override;
 
-    bool getSkipState() override;
+    bool is_skipping() override;
 
     bool add_exogenous_model(std::unique_ptr<ExogenousModel> exogenous_model);
 

--- a/src/BayesFilters/src/ExogenousModel.cpp
+++ b/src/BayesFilters/src/ExogenousModel.cpp
@@ -22,7 +22,7 @@ bool ExogenousModel::skip(const std::string& what_step, const bool status)
 }
 
 
-bool ExogenousModel::getSkipState()
+bool ExogenousModel::is_skipping()
 {
     return skip_;
 }

--- a/src/BayesFilters/src/FilteringAlgorithm.cpp
+++ b/src/BayesFilters/src/FilteringAlgorithm.cpp
@@ -16,7 +16,7 @@ bool FilteringAlgorithm::boot()
 {
     try
     {
-        filtering_thread_ = std::thread(&FilteringAlgorithm::filteringRecursion, this);
+        filtering_thread_ = std::thread(&FilteringAlgorithm::filtering_recursion, this);
     }
     catch (const std::system_error& e)
     {
@@ -87,19 +87,19 @@ bool FilteringAlgorithm::teardown()
 }
 
 
-unsigned int FilteringAlgorithm::getFilteringStep()
+unsigned int FilteringAlgorithm::step_number()
 {
     return filtering_step_;
 }
 
 
-bool FilteringAlgorithm::isRunning()
+bool FilteringAlgorithm::is_running()
 {
     return run_;
 }
 
 
-void FilteringAlgorithm::filteringRecursion()
+void FilteringAlgorithm::filtering_recursion()
 {
     do
     {
@@ -120,16 +120,16 @@ void FilteringAlgorithm::filteringRecursion()
             teardown_ = true;
         }
 
-        initialization();
+        initialization_step();
 
-        while (runCondition() && !teardown_ && !reset_)
+        while (run_condition() && !teardown_ && !reset_)
         {
-            filteringStep();
+            filtering_step();
 
             ++filtering_step_;
         }
     }
-    while (runCondition() && (run_ || reset_) && !teardown_);
+    while (run_condition() && (run_ || reset_) && !teardown_);
 
     run_ = false;
 }

--- a/src/BayesFilters/src/GaussianCorrection.cpp
+++ b/src/BayesFilters/src/GaussianCorrection.cpp
@@ -31,9 +31,9 @@ bool GaussianCorrection::skip(const bool status)
 }
 
 
-bool GaussianCorrection::freeze_measurements()
+bool GaussianCorrection::freeze_measurements(const Data& data)
 {
-    return getMeasurementModel().freeze();
+    return getMeasurementModel().freeze(data);
 }
 
 

--- a/src/BayesFilters/src/GaussianFilter.cpp
+++ b/src/BayesFilters/src/GaussianFilter.cpp
@@ -16,28 +16,10 @@ GaussianFilter::GaussianFilter(std::unique_ptr<GaussianPrediction> prediction, s
 { }
 
 
-GaussianFilter::GaussianFilter(GaussianFilter&& gf) noexcept :
-    prediction_(std::move(gf.prediction_)),
-    correction_(std::move(gf.correction_))
-{ }
-
-
-GaussianFilter& GaussianFilter::operator=(GaussianFilter&& gf) noexcept
-{
-    if (this == &gf)
-        return *this;
-
-    prediction_ = std::move(gf.prediction_);
-    correction_ = std::move(gf.correction_);
-
-    return *this;
-}
-
-
 bool GaussianFilter::skip(const std::string& what_step, const bool status)
 {
     if (what_step == "prediction" ||
-        what_step == "state"      ||
+        what_step == "state" ||
         what_step == "exogenous")
         return prediction_->skip(what_step, status);
 
@@ -49,8 +31,6 @@ bool GaussianFilter::skip(const std::string& what_step, const bool status)
         bool return_status = true;
 
         return_status &= prediction_->skip("prediction", status);
-        return_status &= prediction_->skip("state", status);
-        return_status &= prediction_->skip("exogenous", status);
 
         return_status &= correction_->skip(status);
 
@@ -58,4 +38,16 @@ bool GaussianFilter::skip(const std::string& what_step, const bool status)
     }
 
     return false;
+}
+
+
+GaussianPrediction& GaussianFilter::prediction()
+{
+    return *prediction_;
+}
+
+
+GaussianCorrection& GaussianFilter::correction()
+{
+    return *correction_;
 }

--- a/src/BayesFilters/src/GaussianPrediction.cpp
+++ b/src/BayesFilters/src/GaussianPrediction.cpp
@@ -38,13 +38,13 @@ bool GaussianPrediction::skip(const std::string& what_step, const bool status)
     {
         getStateModel().skip("state", status);
 
-        skip_ = getStateModel().getSkipState() & getStateModel().exogenous_model().getSkipState();
+        skip_ = getStateModel().is_skipping() & getStateModel().exogenous_model().is_skipping();
     }
     else if (what_step == "exogenous")
     {
         getStateModel().skip("exogenous", status);
 
-        skip_ = getStateModel().getSkipState() & getStateModel().exogenous_model().getSkipState();
+        skip_ = getStateModel().is_skipping() & getStateModel().exogenous_model().is_skipping();
     }
     else
         return false;
@@ -53,7 +53,7 @@ bool GaussianPrediction::skip(const std::string& what_step, const bool status)
 }
 
 
-bool GaussianPrediction::getSkipState()
+bool GaussianPrediction::is_skipping()
 {
     return skip_;
 }

--- a/src/BayesFilters/src/KFPrediction.cpp
+++ b/src/BayesFilters/src/KFPrediction.cpp
@@ -43,7 +43,7 @@ bfl::StateModel& KFPrediction::getStateModel() noexcept
 
 void KFPrediction::predictStep(const GaussianMixture& prev_state, GaussianMixture& pred_state)
 {
-    if (getStateModel().getSkipState())
+    if (getStateModel().is_skipping())
     {
         pred_state = prev_state;
 

--- a/src/BayesFilters/src/LinearStateModel.cpp
+++ b/src/BayesFilters/src/LinearStateModel.cpp
@@ -15,11 +15,11 @@ using namespace Eigen;
 
 void LinearStateModel::propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> prop_states)
 {
-    if (getSkipState() && (have_exogenous_model() && exogenous_model().getSkipState()))
+    if (is_skipping() && (have_exogenous_model() && exogenous_model().is_skipping()))
     {
         prop_states = cur_states;
     }
-    else if (!getSkipState() && (have_exogenous_model() && !exogenous_model().getSkipState()))
+    else if (!is_skipping() && (have_exogenous_model() && !exogenous_model().is_skipping()))
     {
         MatrixXd exogenous_state(cur_states.rows(), cur_states.cols());
 
@@ -27,11 +27,11 @@ void LinearStateModel::propagate(const Eigen::Ref<const Eigen::MatrixXd>& cur_st
 
         prop_states = getStateTransitionMatrix() * cur_states + exogenous_state;
     }
-    else if (!getSkipState())
+    else if (!is_skipping())
     {
         prop_states = getStateTransitionMatrix() * cur_states;
     }
-    else if (have_exogenous_model() && !exogenous_model().getSkipState())
+    else if (have_exogenous_model() && !exogenous_model().is_skipping())
     {
         exogenous_model().propagate(cur_states, prop_states);
     }

--- a/src/BayesFilters/src/PFCorrection.cpp
+++ b/src/BayesFilters/src/PFCorrection.cpp
@@ -29,7 +29,7 @@ bool PFCorrection::skip(const bool status) noexcept
 }
 
 
-bool PFCorrection::freeze_measurements()
+bool PFCorrection::freeze_measurements(const Data& data)
 {
-    return getMeasurementModel().freeze();
+    return getMeasurementModel().freeze(data);
 }

--- a/src/BayesFilters/src/PFPrediction.cpp
+++ b/src/BayesFilters/src/PFPrediction.cpp
@@ -37,13 +37,13 @@ bool PFPrediction::skip(const std::string& what_step, const bool status)
     {
         getStateModel().skip("state", status);
 
-        skip_ = getStateModel().getSkipState() & getStateModel().exogenous_model().getSkipState();
+        skip_ = getStateModel().is_skipping() & getStateModel().exogenous_model().is_skipping();
     }
     else if (what_step == "exogenous")
     {
         getStateModel().skip("exogenous", status);
 
-        skip_ = getStateModel().getSkipState() & getStateModel().exogenous_model().getSkipState();
+        skip_ = getStateModel().is_skipping() & getStateModel().exogenous_model().is_skipping();
     }
     else
         return false;
@@ -52,7 +52,7 @@ bool PFPrediction::skip(const std::string& what_step, const bool status)
 }
 
 
-bool PFPrediction::getSkipState()
+bool PFPrediction::is_skipping()
 {
     return skip_;
 }

--- a/src/BayesFilters/src/ParticleFilter.cpp
+++ b/src/BayesFilters/src/ParticleFilter.cpp
@@ -25,28 +25,6 @@ noexcept :
 { }
 
 
-ParticleFilter::ParticleFilter(ParticleFilter&& pf) noexcept :
-    initialization_(std::move(pf.initialization_)),
-    prediction_(std::move(pf.prediction_)),
-    correction_(std::move(pf.correction_)),
-    resampling_(std::move(pf.resampling_))
-{ }
-
-
-ParticleFilter& ParticleFilter::operator=(ParticleFilter&& pf) noexcept
-{
-    if (this == &pf)
-        return *this;
-
-    initialization_ = std::move(pf.initialization_);
-    prediction_     = std::move(pf.prediction_);
-    correction_     = std::move(pf.correction_);
-    resampling_     = std::move(pf.resampling_);
-
-    return *this;
-}
-
-
 bool ParticleFilter::skip(const std::string& what_step, const bool status)
 {
     if (what_step == "prediction" ||
@@ -62,8 +40,6 @@ bool ParticleFilter::skip(const std::string& what_step, const bool status)
         bool return_status = true;
 
         return_status &= prediction_->skip("prediction", status);
-        return_status &= prediction_->skip("state", status);
-        return_status &= prediction_->skip("exogenous", status);
 
         return_status &= correction_->skip(status);
 
@@ -71,4 +47,28 @@ bool ParticleFilter::skip(const std::string& what_step, const bool status)
     }
 
     return false;
+}
+
+
+ParticleSetInitialization& ParticleFilter::initialization()
+{
+    return *initialization_;
+}
+
+
+PFPrediction& ParticleFilter::prediction()
+{
+    return *prediction_;
+}
+
+
+PFCorrection& ParticleFilter::correction()
+{
+    return *correction_;
+}
+
+
+Resampling& ParticleFilter::resampling()
+{
+    return *resampling_;
 }

--- a/src/BayesFilters/src/StateModel.cpp
+++ b/src/BayesFilters/src/StateModel.cpp
@@ -24,7 +24,7 @@ bool StateModel::skip(const std::string& what_step, const bool status)
 }
 
 
-bool StateModel::getSkipState()
+bool StateModel::is_skipping()
 {
     return skip_;
 }
@@ -52,7 +52,7 @@ ExogenousModel& StateModel::exogenous_model()
     if (exogenous_model_)
         return *exogenous_model_;
 
-    throw std::runtime_error("ERROR::LTISTATEMODEL::GET_EXOGENOUS_MODEL\nERROR:\n\tNo valid ExogenousModel object present in LTIStateModel object. Use LTIStateModel::add_exogenous_model() to add one.");
+    throw std::runtime_error("ERROR::STATEMODEL::GET_EXOGENOUS_MODEL\nERROR:\n\tNo valid ExogenousModel object present in LTIStateModel object. Use LTIStateModel::add_exogenous_model() to add one.");
 }
 
 

--- a/src/BayesFilters/src/UKFPrediction.cpp
+++ b/src/BayesFilters/src/UKFPrediction.cpp
@@ -79,7 +79,7 @@ bfl::StateModel& UKFPrediction::getStateModel() noexcept
 
 void UKFPrediction::predictStep(const GaussianMixture& prev_state, GaussianMixture& pred_state)
 {
-    if (getStateModel().getSkipState())
+    if (getStateModel().is_skipping())
     {
         pred_state = prev_state;
 

--- a/test/test_KF/main.cpp
+++ b/test/test_KF/main.cpp
@@ -39,22 +39,22 @@ public:
     { }
 
 protected:
-    bool runCondition() override
+    bool run_condition() override
     {
-        if (getFilteringStep() < simulation_steps_)
+        if (step_number() < simulation_steps_)
             return true;
         else
             return false;
     }
 
 
-    bool initialization() override
+    bool initialization_step() override
     {
         return true;
     }
 
 
-    void filteringStep() override
+    void filtering_step() override
     {
         prediction_->predict(corrected_state_, predicted_state_);
 

--- a/test/test_KF/main.cpp
+++ b/test/test_KF/main.cpp
@@ -56,12 +56,9 @@ protected:
 
     void filtering_step() override
     {
-        prediction_->predict(corrected_state_, predicted_state_);
-
-        if (correction_->freeze_measurements())
-            correction_->correct(predicted_state_, corrected_state_);
-        else
-            corrected_state_ = predicted_state_;
+        prediction().predict(corrected_state_, predicted_state_);
+        correction().freeze_measurements();
+        correction().correct(predicted_state_, corrected_state_);
 
         log();
     }

--- a/test/test_SIS/main.cpp
+++ b/test/test_SIS/main.cpp
@@ -45,9 +45,9 @@ public:
     { }
 
 protected:
-    bool runCondition() override
+    bool run_condition() override
     {
-        if (getFilteringStep() < simulation_steps_)
+        if (step_number() < simulation_steps_)
             return true;
         else
             return false;
@@ -63,11 +63,11 @@ protected:
         return  sis_filenames;
     }
 
-    bool initialization() override
+    bool initialization_step() override
     {
         estimates_extraction_.setMethod(EstimatesExtraction::ExtractionMethod::mean);
 
-        if (!SIS::initialization())
+        if (!SIS::initialization_step())
             return false;
 
         return true;

--- a/test/test_UKF/main.cpp
+++ b/test/test_UKF/main.cpp
@@ -57,12 +57,9 @@ protected:
 
     void filtering_step() override
     {
-        prediction_->predict(corrected_state_, predicted_state_);
-
-        if (correction_->freeze_measurements())
-            correction_->correct(predicted_state_, corrected_state_);
-        else
-            corrected_state_ = predicted_state_;
+        prediction().predict(corrected_state_, predicted_state_);
+        correction().freeze_measurements();
+        correction().correct(predicted_state_, corrected_state_);
 
         log();
     }

--- a/test/test_UKF/main.cpp
+++ b/test/test_UKF/main.cpp
@@ -40,22 +40,22 @@ public:
     { }
 
 protected:
-    bool runCondition() override
+    bool run_condition() override
     {
-        if (getFilteringStep() < simulation_steps_)
+        if (step_number() < simulation_steps_)
             return true;
         else
             return false;
     }
 
 
-    bool initialization() override
+    bool initialization_step() override
     {
         return true;
     }
 
 
-    void filteringStep() override
+    void filtering_step() override
     {
         prediction_->predict(corrected_state_, predicted_state_);
 

--- a/test/test_UPF/main.cpp
+++ b/test/test_UPF/main.cpp
@@ -52,9 +52,9 @@ public:
     { }
 
 protected:
-    bool runCondition() override
+    bool run_condition() override
     {
-        if (getFilteringStep() < simulation_steps_)
+        if (step_number() < simulation_steps_)
             return true;
         else
             return false;
@@ -70,11 +70,11 @@ protected:
         return  sis_filenames;
     }
 
-    bool initialization() override
+    bool initialization_step() override
     {
         estimates_extraction_.setMethod(EstimatesExtraction::ExtractionMethod::mean);
 
-        if (!SIS::initialization())
+        if (!SIS::initialization_step())
             return false;
 
         /* Initialize initial mean and covariance for each particle. */

--- a/test/test_UPF_MAP/main.cpp
+++ b/test/test_UPF_MAP/main.cpp
@@ -47,9 +47,9 @@ public:
     { }
 
 protected:
-    bool runCondition() override
+    bool run_condition() override
     {
-        if (getFilteringStep() < simulation_steps_)
+        if (step_number() < simulation_steps_)
             return true;
         else
             return false;
@@ -65,11 +65,11 @@ protected:
         return sis_filenames;
     }
 
-    bool initialization() override
+    bool initialization_step() override
     {
         estimates_extraction_.setMethod(EstimatesExtraction::ExtractionMethod::map);
 
-        if (!SIS::initialization())
+        if (!SIS::initialization_step())
             return false;
 
         /* Initialize initial mean and covariance for each particle. */
@@ -88,9 +88,9 @@ protected:
         return true;
     }
 
-    void filteringStep() override
+    void filtering_step() override
     {
-        SIS::filteringStep();
+        SIS::filtering_step();
 
         /* Update previous corrected particles. */
         previous_corr_particle_ = cor_particle_;
@@ -102,7 +102,7 @@ protected:
 
         for (std::size_t i = 0; i < probabilities.rows(); i++)
             for (std::size_t j = 0; j < probabilities.rows(); j++)
-                probabilities(i, j) = prediction_->getStateModel().getTransitionProbability(previous_corr_particle.col(j), corr_particle.col(i)).coeff(0);
+                probabilities(i, j) = prediction().getStateModel().getTransitionProbability(previous_corr_particle.col(j), corr_particle.col(i)).coeff(0);
 
         return probabilities;
     }
@@ -113,7 +113,7 @@ protected:
 
         /* Get likelihoods. */
         VectorXd likelihoods;
-        std::tie(std::ignore, likelihoods) = correction_->getLikelihood();
+        std::tie(std::ignore, likelihoods) = correction().getLikelihood();
 
         /* Get transition probability matrix. */
         MatrixXd probabilities = getTransitionProbabilityMatrix(cor_particle_.state(), previous_corr_particle_.state());

--- a/test/test_mixed_KF_SUKF/main.cpp
+++ b/test/test_mixed_KF_SUKF/main.cpp
@@ -57,12 +57,9 @@ protected:
 
     void filtering_step() override
     {
-        prediction_->predict(corrected_state_, predicted_state_);
-
-        if (correction_->freeze_measurements())
-            correction_->correct(predicted_state_, corrected_state_);
-        else
-            corrected_state_ = predicted_state_;
+        prediction().predict(corrected_state_, predicted_state_);
+        correction().freeze_measurements();
+        correction().correct(predicted_state_, corrected_state_);
 
         log();
     }

--- a/test/test_mixed_KF_SUKF/main.cpp
+++ b/test/test_mixed_KF_SUKF/main.cpp
@@ -40,22 +40,22 @@ public:
     { }
 
 protected:
-    bool runCondition() override
+    bool run_condition() override
     {
-        if (getFilteringStep() < simulation_steps_)
+        if (step_number() < simulation_steps_)
             return true;
         else
             return false;
     }
 
 
-    bool initialization() override
+    bool initialization_step() override
     {
         return true;
     }
 
 
-    void filteringStep() override
+    void filtering_step() override
     {
         prediction_->predict(corrected_state_, predicted_state_);
 

--- a/test/test_mixed_KF_UKF/main.cpp
+++ b/test/test_mixed_KF_UKF/main.cpp
@@ -57,12 +57,9 @@ protected:
 
     void filtering_step() override
     {
-        prediction_->predict(corrected_state_, predicted_state_);
-
-        if (correction_->freeze_measurements())
-            correction_->correct(predicted_state_, corrected_state_);
-        else
-            corrected_state_ = predicted_state_;
+        prediction().predict(corrected_state_, predicted_state_);
+        correction().freeze_measurements();
+        correction().correct(predicted_state_, corrected_state_);
 
         log();
     }

--- a/test/test_mixed_KF_UKF/main.cpp
+++ b/test/test_mixed_KF_UKF/main.cpp
@@ -40,22 +40,22 @@ public:
     { }
 
 protected:
-    bool runCondition() override
+    bool run_condition() override
     {
-        if (getFilteringStep() < simulation_steps_)
+        if (step_number() < simulation_steps_)
             return true;
         else
             return false;
     }
 
 
-    bool initialization() override
+    bool initialization_step() override
     {
         return true;
     }
 
 
-    void filteringStep() override
+    void filtering_step() override
     {
         prediction_->predict(corrected_state_, predicted_state_);
 

--- a/test/test_mixed_UKF_KF/main.cpp
+++ b/test/test_mixed_UKF_KF/main.cpp
@@ -57,12 +57,9 @@ protected:
 
     void filtering_step() override
     {
-        prediction_->predict(corrected_state_, predicted_state_);
-
-        if (correction_->freeze_measurements())
-            correction_->correct(predicted_state_, corrected_state_);
-        else
-            corrected_state_ = predicted_state_;
+        prediction().predict(corrected_state_, predicted_state_);
+        correction().freeze_measurements();
+        correction().correct(predicted_state_, corrected_state_);
 
         log();
     }

--- a/test/test_mixed_UKF_KF/main.cpp
+++ b/test/test_mixed_UKF_KF/main.cpp
@@ -40,22 +40,22 @@ public:
     { }
 
 protected:
-    bool runCondition() override
+    bool run_condition() override
     {
-        if (getFilteringStep() < simulation_steps_)
+        if (step_number() < simulation_steps_)
             return true;
         else
             return false;
     }
 
 
-    bool initialization() override
+    bool initialization_step() override
     {
         return true;
     }
 
 
-    void filteringStep() override
+    void filtering_step() override
     {
         prediction_->predict(corrected_state_, predicted_state_);
 


### PR DESCRIPTION
This PR is the fourth of a series incorporating commits from `claudiofantacci/bayes-filters-lib` and `xenvre/bayes-filters-lib`.

In this PR:

### New interfaces

- Add `Skipper` interface modelling skipping functionalities
- Add `Filter` interface class describing Bayes filter functionalities

### Use of new interfaces in existing classes

- `Skippable` inherits from `Skipper`
- `FilteringAlgorithm` inherits form `Filter`
- `FilteringAlgorithm` inherits form `Skipper`

### Change in `FilteringAlgorithm` interface

- `initialization()` renamed to `initialization_step()`
- `isRunning()` renamed to `is_running()`
- `filteringRecursion()` renamed to `filtering_recursion()`
- `filteringStep()` renamed to `step_number()`
- `runCondition()` renamed to `run_condition()`

### Change in `GaussianFilter` interface

- add method `predition()` returning reference to the underlying `GaussianPrediction` `predition_` (now private)
- add method `correction()` returning reference to the underlying `GaussianCorrection`  `correction_`  (now private)

### Change in `ParticleFilter` interface
- add method `initialization()` returning reference to the underlying `ParticleSetInitialization` `initialization_`
- add method `prediction()` returning reference to the underlying `PFPrediction` `prediction_`  (now private)
- add method `correction()` returning reference to the underlying `PFCorrection` `correction_` (now private)
- add method `resampling()` returning reference to the underlying `Resampling` `resampling_`

### Misc.

- `Skippable::getSkipState()` is renamed in `Skippable::is_skipping()`
- Add default ctor in class `FilteringAlgorithm`
- Add default dtor in classes `GaussianFilter`, `SIS`
- Delete copy constructor/assignment and default move constructor/assignment in classes `FilteringAlgorithm`, `GaussianFilter`, `ParticleFilter`, `SIS`
- Move `SIS::log_file_names` implementation from `.h.` to `.cpp`
- Add default argument `const bfl::Data& data = Data()` to `{PFCorrection, GaussianCorrection}::freeze_measurements()` such that it can be passed to the underlying `MeasurementModel::freeze(const bfl::Data&)`

### Tests

Tests have been updated accordingly

### Changelog

Changelog has been updated accordingly

Fixes #72 
