### PR TITLE
Implement a more refined description of the state/measurement size description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,34 @@
 # 📜 BayesFilters changelog
 
-## 🔖 Version 0.9.101
+## 🔖 Version 0.10.100
 ##### `Filtering utilities`
 - Improve documentation of methods `bfl::utils::quaternion_to_rotation_vector()`, `bfl::utils::rotation_vector_to_quaternion()`, `bfl::utils::sum_quaternion_rotation_vector()`, `bfl::utils::diff_quaternion()`,`bfl::utils::mean_quaternion()`.
+- Implemented class `VectorDescription` which describes the size of the inner components of a state/measurement vector (linear, rotational and noise parts).
+- Updated the `FunctionEvaluation` alias within `sigma_point.h` in order to use a `VectorDescription` as one of the outputs.
+- Updated implementation of variants of the `unscented_transform()` transforms within `sigma_point.h` taking into account the new definition of the `FunctionEvaluation` alias.
+- Added a constructor to the `UTWeight` struct such that it can be constructed starting from a `VectorDescription` description.
 
+##### `Filtering functions`
+- Substituted `ExogenousProcess::getOutputSize()` with `ExogenousProcess::getStateDescription()` which uses the `VectorDescription` class to describe the size of the output of the exogenous process.
+- Substituted `StateProcess::getOutputSize()` with pure virtual `StateProcess::getStateDescription()` which uses the `VectorDescription` class to describe the size of the state of the state model.
+- Added pure virtual method `StateProcess::getInputDescription()` which uses the `VectorDescription` class to describe the size of the input to the state model.
+- Substituted `MeasurementModel::getOutputSize()` with `MeasuremnetModel::getMeasurementDescription()` which uses the `VectorDescription` class to describe the size of the measurement of the measurement model. This method is not mandatory and a default implementation (raising an exception) is provided as not all measurements are provided with a vectorial description.
+- Added method `MeasurementModel::getInputDescription()` which uses the `VectorDescription` class to describe the size of the input to the measurement model. This method is not mandatory and a default implementation (raising an exception) is provided as not all measurements are provided with a vectorial description.
+- Updated implementation of class `WhiteNoiseAcceleration` to take into account changes in the `StateModel` interface.
+- Updated implementation of class `AdditiveStateModel` to take into account changes in the `StateModel` interface.
+- Updated implementation of class `SimulatedLinearSensor` to take into account changes in the `StateModel` and `MeasurementModel` interfaces.
+
+##### `Filtering algorithms`
+- Updated implementation of `SUKFCorrection` in order to extract relevant information on the measurement size using the `VectorDescription` of the adopted measurement model.
+- Updated implementation of `UKFCorrection` in order to extract relevant information on the measurement size using the `VectorDescription` of the adopted measurement model.
+- Updated implementation of `UKFPrediction` in order to extract relevant information on state size using the `VectorDescription` of the adopted state model.
+- Added support for measurement models having a time-varying input `VectorDescription` in `UKFCorrection`. The feature is enabled using a boolean argument in the constructor.
+
+##### `Test`
+- Updated tests 'test_Gaussian_Density_UVR`, `test_UKF`, `test_UPF`, `test_UPF_MAP`, `test_mixed_KF_SUKF`, `test_mixed_KF_UKF` and `test_mixed_UKF_KF` to account for the changes in the interface of the `AdditiveMeasurementModel`, `UKFPrediction`, `UKFCorrection` and `SUKFCorrection` classes.
+
+##### `CMake`
+- Minor version increases since API compatibility is broken.
 
 ## 🔖 Version 0.9.0
 ##### `CMake`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ cmake_minimum_required(VERSION 3.5)
 
 project(BayesFilters
         LANGUAGES CXX
-        VERSION 0.9.101)
+        VERSION 0.10.100)
 
 set(CMAKE_CXX_STANDARD 11)
 

--- a/src/BayesFilters/CMakeLists.txt
+++ b/src/BayesFilters/CMakeLists.txt
@@ -71,6 +71,7 @@ set(${LIBRARY_TARGET_NAME}_FU_HDR
         include/BayesFilters/HistoryBuffer.h
         include/BayesFilters/Logger.h
         include/BayesFilters/ParticleSet.h
+        include/BayesFilters/VectorDescription.h
         include/BayesFilters/sigma_point.h
         include/BayesFilters/utils.h
 )
@@ -131,6 +132,7 @@ set(${LIBRARY_TARGET_NAME}_FU_SRC
         src/HistoryBuffer.cpp
         src/Logger.cpp
         src/ParticleSet.cpp
+        src/VectorDescription.cpp
         src/sigma_point.cpp
 )
 

--- a/src/BayesFilters/include/BayesFilters/AdditiveStateModel.h
+++ b/src/BayesFilters/include/BayesFilters/AdditiveStateModel.h
@@ -9,6 +9,7 @@
 #define ADDITIVESTATEMODEL_H
 
 #include <BayesFilters/StateModel.h>
+#include <BayesFilters/VectorDescription.h>
 
 namespace bfl {
     class AdditiveStateModel;
@@ -22,6 +23,7 @@ public:
 
     virtual void motion(const Eigen::Ref<const Eigen::MatrixXd>& cur_states, Eigen::Ref<Eigen::MatrixXd> mot_states) override;
 
+    virtual VectorDescription getInputDescription();
 
 protected:
     AdditiveStateModel() noexcept = default;

--- a/src/BayesFilters/include/BayesFilters/ExogenousProcess.h
+++ b/src/BayesFilters/include/BayesFilters/ExogenousProcess.h
@@ -8,6 +8,8 @@
 #ifndef EXOGENOUSPROCESS_H
 #define EXOGENOUSPROCESS_H
 
+#include <BayesFilters/VectorDescription.h>
+
 #include <Eigen/Dense>
 
 namespace bfl {
@@ -23,9 +25,9 @@ public:
     virtual bool setProperty(const std::string& property) = 0;
 
     /**
-     * Returns the linear and circular size of the output of the state equation.
+     * Returns the vector description of the output of the state equation.
      */
-    virtual std::pair<std::size_t, std::size_t> getOutputSize() const = 0;
+    virtual VectorDescription getStateDescription() const = 0;
 };
 
 #endif /* EXOGENOUSPROCESS_H */

--- a/src/BayesFilters/include/BayesFilters/MeasurementModel.h
+++ b/src/BayesFilters/include/BayesFilters/MeasurementModel.h
@@ -10,6 +10,7 @@
 
 #include <BayesFilters/Data.h>
 #include <BayesFilters/Logger.h>
+#include <BayesFilters/VectorDescription.h>
 
 #include <memory>
 #include <string>
@@ -42,8 +43,11 @@ public:
 
     virtual bool setProperty(const std::string& property);
 
-    /* Returns the linear and circular size of the output of the measurement equation. */
-    virtual std::pair<std::size_t, std::size_t> getOutputSize() const = 0;
+    /* Returns the vector description of the input to the measurement equation. */
+    virtual VectorDescription getInputDescription() const;
+
+    /* Returns the vector description of the output measurement of the measurement equation. */
+    virtual VectorDescription getMeasurementDescription() const;
 };
 
 #endif /* MEASUREMENTMODEL_H */

--- a/src/BayesFilters/include/BayesFilters/SUKFCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/SUKFCorrection.h
@@ -43,7 +43,7 @@ public:
      * The input argument meas_sub_size is the sub-size, J, of the
      * measurement vector y in R^M such that M = k * J for some positive integer k.
      */
-    SUKFCorrection(std::unique_ptr<AdditiveMeasurementModel> measurement_model, const std::size_t state_size, const double alpha, const double beta, const double kappa, const std::size_t measurement_sub_size, const bool use_reduced_noise_covariance_matrix) noexcept;
+    SUKFCorrection(std::unique_ptr<AdditiveMeasurementModel> measurement_model, const double alpha, const double beta, const double kappa, const std::size_t measurement_sub_size, const bool use_reduced_noise_covariance_matrix) noexcept;
 
     SUKFCorrection(SUKFCorrection&& sukf_correction) noexcept;
 

--- a/src/BayesFilters/include/BayesFilters/SimulatedLinearSensor.h
+++ b/src/BayesFilters/include/BayesFilters/SimulatedLinearSensor.h
@@ -10,6 +10,7 @@
 
 #include <BayesFilters/LinearModel.h>
 #include <BayesFilters/SimulatedStateModel.h>
+#include <BayesFilters/VectorDescription.h>
 
 #include <memory>
 
@@ -31,17 +32,18 @@ public:
 
     std::pair<bool, bfl::Data> measure(const Data& data = Data()) const override;
 
-    std::pair<std::size_t, std::size_t> getOutputSize() const override;
+    VectorDescription getInputDescription() const override;
 
+    VectorDescription getMeasurementDescription() const override;
 
 protected:
     std::unique_ptr<bfl::SimulatedStateModel> simulated_state_model_;
 
     Eigen::MatrixXd measurement_;
 
-    std::size_t dim_linear_;
+    VectorDescription input_description_;
 
-    std::size_t dim_circular_;
+    VectorDescription measurement_description_;
 
     void log() override;
 };

--- a/src/BayesFilters/include/BayesFilters/StateProcess.h
+++ b/src/BayesFilters/include/BayesFilters/StateProcess.h
@@ -8,6 +8,8 @@
 #ifndef STATEPROCESS_H
 #define STATEPROCESS_H
 
+#include <BayesFilters/VectorDescription.h>
+
 #include <Eigen/Dense>
 
 namespace bfl {
@@ -25,9 +27,14 @@ public:
     virtual bool setProperty(const std::string& property) = 0;
 
     /**
-     * Returns the linear and circular size of the output of the state equation.
+     * Returns the vector description of the input to the state equation.
      */
-    virtual std::pair<std::size_t, std::size_t> getOutputSize() const = 0;
+    virtual VectorDescription getInputDescription() = 0;
+
+    /**
+     * Returns the vector description of the output of the state equation.
+     */
+    virtual VectorDescription getStateDescription() = 0;
 };
 
 #endif /* STATEPROCESS_H */

--- a/src/BayesFilters/include/BayesFilters/UKFCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/UKFCorrection.h
@@ -24,7 +24,7 @@ namespace bfl {
 class bfl::UKFCorrection : public GaussianCorrection
 {
 public:
-    UKFCorrection(std::unique_ptr<MeasurementModel> meas_model, const double alpha, const double beta, const double kappa) noexcept;
+    UKFCorrection(std::unique_ptr<MeasurementModel> meas_model, const double alpha, const double beta, const double kappa, const bool update_weights_online = false) noexcept;
 
     UKFCorrection(std::unique_ptr<AdditiveMeasurementModel> meas_model, const double alpha, const double beta, const double kappa) noexcept;
 
@@ -55,6 +55,21 @@ protected:
      * Unscented transform weight.
      */
     sigma_point::UTWeight ut_weight_;
+
+    /**
+     * The unscented transform for a generic non-additive measurement model requires the computation of 2 * n + 1 sigma points
+     * where n depends not only on the size of the input state but also on the size of the noise.
+     * While the state size is fixed, the noise size might depend on the number of measurements available, hence n might change online.
+     * Since the unscented transform weights, stored in ut_weight_, depend on n the user can specify, using the ctor input parameter
+     * update_weights_online, that the weights have to be re-computed at each iteration.
+     */
+    const bool update_weights_online_ = false;
+
+    const double ut_alpha_;
+
+    const double ut_beta_;
+
+    const double ut_kappa_;
 
     Eigen::MatrixXd innovations_;
 

--- a/src/BayesFilters/include/BayesFilters/UKFCorrection.h
+++ b/src/BayesFilters/include/BayesFilters/UKFCorrection.h
@@ -24,9 +24,9 @@ namespace bfl {
 class bfl::UKFCorrection : public GaussianCorrection
 {
 public:
-    UKFCorrection(std::unique_ptr<MeasurementModel> meas_model, const size_t n, const double alpha, const double beta, const double kappa) noexcept;
+    UKFCorrection(std::unique_ptr<MeasurementModel> meas_model, const double alpha, const double beta, const double kappa) noexcept;
 
-    UKFCorrection(std::unique_ptr<AdditiveMeasurementModel> meas_model, const size_t n, const double alpha, const double beta, const double kappa) noexcept;
+    UKFCorrection(std::unique_ptr<AdditiveMeasurementModel> meas_model, const double alpha, const double beta, const double kappa) noexcept;
 
     UKFCorrection(UKFCorrection&& ukf_prediction) noexcept;
 

--- a/src/BayesFilters/include/BayesFilters/UKFPrediction.h
+++ b/src/BayesFilters/include/BayesFilters/UKFPrediction.h
@@ -31,9 +31,9 @@ public:
         Additive
     };
 
-    UKFPrediction(std::unique_ptr<StateModel> state_model, const size_t n, const double alpha, const double beta, const double kappa) noexcept;
+    UKFPrediction(std::unique_ptr<StateModel> state_model, const double alpha, const double beta, const double kappa) noexcept;
 
-    UKFPrediction(std::unique_ptr<AdditiveStateModel> state_model, const size_t n, const double alpha, const double beta, const double kappa) noexcept;
+    UKFPrediction(std::unique_ptr<AdditiveStateModel> state_model, const double alpha, const double beta, const double kappa) noexcept;
 
     UKFPrediction(const UKFPrediction& prediction) noexcept = delete;
 

--- a/src/BayesFilters/include/BayesFilters/VectorDescription.h
+++ b/src/BayesFilters/include/BayesFilters/VectorDescription.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2016-2019 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#ifndef VECTORDESCRIPTION_H
+#define VECTORDESCRIPTION_H
+
+#include <cstddef>
+
+namespace bfl {
+    class VectorDescription;
+}
+
+
+class bfl::VectorDescription
+{
+public:
+    enum class CircularType { Euler, Quaternion };
+
+    VectorDescription() = default;
+
+    VectorDescription(const std::size_t linear_components, const std::size_t circular_components = 0, const std::size_t noise_components = 0, const CircularType& circular_type = CircularType::Euler);
+
+    ~VectorDescription() = default;
+
+    std::size_t linear_components() const;
+
+    std::size_t circular_components() const;
+
+    std::size_t noise_components() const;
+
+    std::size_t linear_size() const;
+
+    std::size_t circular_size() const;
+
+    std::size_t noise_size() const;
+
+    std::size_t total_size() const;
+
+    void add_noise_components(const std::size_t& components);
+
+    VectorDescription noiseless_description() const;
+
+    CircularType circular_type = CircularType::Euler;
+
+private:
+
+    std::size_t linear_components_ = 0;
+
+    std::size_t circular_components_ = 0;
+
+    std::size_t noise_components_ = 0;
+};
+
+#endif /* VECTORDESCRIPTION_H */

--- a/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
+++ b/src/BayesFilters/include/BayesFilters/WhiteNoiseAcceleration.h
@@ -9,6 +9,7 @@
 #define WHITENOISEACCELERATION_H
 
 #include <BayesFilters/LinearStateModel.h>
+#include <BayesFilters/VectorDescription.h>
 
 #include <functional>
 #include <random>
@@ -44,7 +45,7 @@ public:
 
     bool setProperty(const std::string& property) override;
 
-    std::pair<std::size_t, std::size_t> getOutputSize() const override;
+    VectorDescription getStateDescription() override;
 
     Eigen::MatrixXd getNoiseSample(const std::size_t num) override;
 

--- a/src/BayesFilters/include/BayesFilters/sigma_point.h
+++ b/src/BayesFilters/include/BayesFilters/sigma_point.h
@@ -8,11 +8,11 @@
 #ifndef SIGMAPOINT_H
 #define SIGMAPOINT_H
 
+#include <BayesFilters/AdditiveMeasurementModel.h>
 #include <BayesFilters/AdditiveStateModel.h>
 #include <BayesFilters/Data.h>
 #include <BayesFilters/ExogenousModel.h>
 #include <BayesFilters/GaussianMixture.h>
-#include <BayesFilters/AdditiveMeasurementModel.h>
 #include <BayesFilters/MeasurementModel.h>
 #include <BayesFilters/StateModel.h>
 

--- a/src/BayesFilters/include/BayesFilters/sigma_point.h
+++ b/src/BayesFilters/include/BayesFilters/sigma_point.h
@@ -45,7 +45,16 @@ namespace sigma_point
          */
         double c;
 
-        UTWeight(std::size_t n, const double alpha, const double beta, const double kappa);
+        /**
+         * Constructs the weights from number of degrees of freedom of the input space and UT parameters alpha, beta and kappa.
+         */
+        UTWeight(std::size_t dof, const double alpha, const double beta, const double kappa);
+
+        /**
+         * Constructs the weights from a bfl::VectorDescription and UT parameters alpha, beta and kappa.
+         * The number of degress of freedom of the input space is determined from the vector description.
+         */
+        UTWeight(const VectorDescription& vector_description, const double alpha, const double beta, const double kappa);
     };
 
     void unscented_weights(const std::size_t n, const double alpha, const double beta, const double kappa, Eigen::Ref<Eigen::VectorXd> weight_mean, Eigen::Ref<Eigen::VectorXd> weight_covariance, double& c);

--- a/src/BayesFilters/include/BayesFilters/sigma_point.h
+++ b/src/BayesFilters/include/BayesFilters/sigma_point.h
@@ -15,6 +15,7 @@
 #include <BayesFilters/GaussianMixture.h>
 #include <BayesFilters/MeasurementModel.h>
 #include <BayesFilters/StateModel.h>
+#include <BayesFilters/VectorDescription.h>
 
 #include <functional>
 
@@ -29,11 +30,9 @@ namespace sigma_point
      * A FunctionEvaluation return
      * - a boolean indicating if the evaluation was successful
      * - the output data in the form of bfl::Data
-     * - the output size as a pair of std::size_t indicating linear and circular size
+     * - the description of the output in the form of bfl::VectorDescription
      */
-    using OutputSize = std::pair<std::size_t, std::size_t>;
-
-    using FunctionEvaluation = std::function<std::tuple<bool, bfl::Data, OutputSize>(const Eigen::Ref<const Eigen::MatrixXd>&)>;
+    using FunctionEvaluation = std::function<std::tuple<bool, bfl::Data, bfl::VectorDescription>(const Eigen::Ref<const Eigen::MatrixXd>&)>;
 
     struct UTWeight
     {

--- a/src/BayesFilters/src/AdditiveStateModel.cpp
+++ b/src/BayesFilters/src/AdditiveStateModel.cpp
@@ -17,3 +17,12 @@ void AdditiveStateModel::motion(const Ref<const MatrixXd>& cur_states, Ref<Matri
 
     mot_states += getNoiseSample(mot_states.cols());
 }
+
+
+VectorDescription AdditiveStateModel::getInputDescription()
+{
+    VectorDescription input_description = getStateDescription();
+    input_description.add_noise_components(getNoiseCovarianceMatrix().rows());
+
+    return input_description;
+}

--- a/src/BayesFilters/src/MeasurementModel.cpp
+++ b/src/BayesFilters/src/MeasurementModel.cpp
@@ -24,3 +24,18 @@ bool MeasurementModel::setProperty(const std::string& property)
     static_cast<void>(property);
     return false;
 }
+
+
+
+VectorDescription MeasurementModel::getInputDescription() const
+{
+    /* Not all measurement model have a vector-valued input. */
+    throw std::runtime_error("ERROR::MEASUREMENTMODEL::GETSTATEDESCRIPTION\nERROR:\n\tMethod not implemented.");
+}
+
+
+VectorDescription MeasurementModel::getMeasurementDescription() const
+{
+    /* Not all measurement model have a vector-valued output. */
+    throw std::runtime_error("ERROR::MEASUREMENTMODEL::GETMEASUREMENTDESCRIPTION\nERROR:\n\tMethod not implemented.");
+}

--- a/src/BayesFilters/src/UKFCorrection.cpp
+++ b/src/BayesFilters/src/UKFCorrection.cpp
@@ -18,11 +18,16 @@ UKFCorrection::UKFCorrection
     std::unique_ptr<MeasurementModel> measurement_model,
     const double alpha,
     const double beta,
-    const double kappa
+    const double kappa,
+    const bool update_weights_online
 ) noexcept :
     measurement_model_(std::move(measurement_model)),
     type_(UKFCorrectionType::Generic),
-    ut_weight_(measurement_model_->getInputDescription(), alpha, beta, kappa)
+    ut_weight_(measurement_model_->getInputDescription(), alpha, beta, kappa),
+    update_weights_online_(update_weights_online),
+    ut_alpha_(alpha),
+    ut_beta_(beta),
+    ut_kappa_(kappa)
 { }
 
 
@@ -35,7 +40,10 @@ UKFCorrection::UKFCorrection
 ) noexcept :
     additive_measurement_model_(std::move(measurement_model)),
     type_(UKFCorrectionType::Additive),
-    ut_weight_(additive_measurement_model_->getInputDescription().noiseless_description(), alpha, beta, kappa)
+    ut_weight_(additive_measurement_model_->getInputDescription().noiseless_description(), alpha, beta, kappa),
+    ut_alpha_(alpha),
+    ut_beta_(beta),
+    ut_kappa_(kappa)
 { }
 
 
@@ -43,7 +51,11 @@ UKFCorrection::UKFCorrection(UKFCorrection&& ukf_correction) noexcept :
     measurement_model_(std::move(ukf_correction.measurement_model_)),
     additive_measurement_model_(std::move(ukf_correction.additive_measurement_model_)),
     type_(ukf_correction.type_),
-    ut_weight_(ukf_correction.ut_weight_)
+    ut_weight_(ukf_correction.ut_weight_),
+    update_weights_online_(ukf_correction.update_weights_online_),
+    ut_alpha_(ukf_correction.ut_alpha_),
+    ut_beta_(ukf_correction.ut_beta_),
+    ut_kappa_(ukf_correction.ut_kappa_)
 { }
 
 
@@ -101,6 +113,9 @@ void UKFCorrection::correctStep(const GaussianMixture& pred_state, GaussianMixtu
         MatrixXd noise_covariance_matrix;
         std::tie(std::ignore, noise_covariance_matrix) = model.getNoiseCovarianceMatrix();
         pred_state_augmented.augmentWithNoise(noise_covariance_matrix);
+
+        if (update_weights_online_)
+            ut_weight_ = UTWeight(measurement_model_->getInputDescription(), ut_alpha_, ut_beta_, ut_kappa_);
 
         std::tie(valid, predicted_meas_, Pxy) = sigma_point::unscented_transform(pred_state_augmented, ut_weight_, *measurement_model_);
     }

--- a/src/BayesFilters/src/UKFPrediction.cpp
+++ b/src/BayesFilters/src/UKFPrediction.cpp
@@ -15,28 +15,26 @@ using namespace Eigen;
 UKFPrediction::UKFPrediction
 (
     std::unique_ptr<StateModel> state_model,
-    const size_t n,
     const double alpha,
     const double beta,
     const double kappa
 ) noexcept :
     state_model_(std::move(state_model)),
     type_(UKFPredictionType::Generic),
-    ut_weight_(n, alpha, beta, kappa)
+    ut_weight_(state_model_->getInputDescription(), alpha, beta, kappa)
 { }
 
 
 UKFPrediction::UKFPrediction
 (
     std::unique_ptr<AdditiveStateModel> state_model,
-    const size_t n,
     const double alpha,
     const double beta,
     const double kappa
 ) noexcept :
     add_state_model_(std::move(state_model)),
     type_(UKFPredictionType::Additive),
-    ut_weight_(n, alpha, beta, kappa)
+    ut_weight_(add_state_model_->getInputDescription().noiseless_description(), alpha, beta, kappa)
 { }
 
 

--- a/src/BayesFilters/src/VectorDescription.cpp
+++ b/src/BayesFilters/src/VectorDescription.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2016-2019 Istituto Italiano di Tecnologia (IIT)
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD 3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+#include <BayesFilters/VectorDescription.h>
+
+using namespace bfl;
+
+
+VectorDescription::VectorDescription
+(
+    const std::size_t linear_components,
+    const std::size_t circular_components,
+    const std::size_t noise_components,
+    const VectorDescription::CircularType& circular_type
+) :
+    linear_components_(linear_components),
+    circular_components_(circular_components),
+    noise_components_(noise_components),
+    circular_type(circular_type)
+{}
+
+
+std::size_t VectorDescription::linear_components() const
+{
+    return linear_components_;
+}
+
+
+std::size_t VectorDescription::circular_components() const
+{
+    return circular_components_;
+}
+
+
+std::size_t VectorDescription::noise_components() const
+{
+    return noise_components_;
+}
+
+
+std::size_t VectorDescription::linear_size() const
+{
+    return linear_components_;
+}
+
+
+std::size_t VectorDescription::circular_size() const
+{
+    if (circular_type == CircularType::Quaternion)
+        return circular_components_ * 4;
+
+    return circular_components_;
+}
+
+
+std::size_t VectorDescription::noise_size() const
+{
+    return noise_components_;
+}
+
+
+std::size_t VectorDescription::total_size() const
+{
+    return linear_size() + circular_size() + noise_size();
+}
+
+
+void VectorDescription::add_noise_components(const std::size_t& components)
+{
+    noise_components_ += components;
+}
+
+
+VectorDescription VectorDescription::noiseless_description() const
+{
+    return VectorDescription(linear_components_, circular_components_, 0, circular_type);
+}

--- a/src/BayesFilters/src/WhiteNoiseAcceleration.cpp
+++ b/src/BayesFilters/src/WhiteNoiseAcceleration.cpp
@@ -52,6 +52,8 @@ struct WhiteNoiseAcceleration::ImplData
 
                 Q_ = Q;
 
+                state_description_ = VectorDescription(2);
+
                 break;
             }
 
@@ -64,6 +66,8 @@ struct WhiteNoiseAcceleration::ImplData
                 Q_ = MatrixXd(4, 4);
                 Q_ << Q, Matrix2d::Zero(),
                       Matrix2d::Zero(), Q;
+
+                state_description_ = VectorDescription(4);
 
                 break;
             }
@@ -79,6 +83,8 @@ struct WhiteNoiseAcceleration::ImplData
                 Q_ << Q, Matrix2d::Zero(), Matrix2d::Zero(),
                       Matrix2d::Zero(), Q, Matrix2d::Zero(),
                       Matrix2d::Zero(), Matrix2d::Zero(), Q;
+
+                state_description_ = VectorDescription(6);
 
                 break;
             }
@@ -99,6 +105,11 @@ struct WhiteNoiseAcceleration::ImplData
      * Power spectral density [length]^2/[time]^3.
      */
     double tilde_q_;
+
+    /**
+     * State description.
+     */
+    VectorDescription state_description_;
 
     /**
      * State transition matrix.
@@ -174,9 +185,9 @@ bool WhiteNoiseAcceleration::setProperty(const std::string& property)
 }
 
 
-std::pair<std::size_t, std::size_t> WhiteNoiseAcceleration::getOutputSize() const
+VectorDescription WhiteNoiseAcceleration::getStateDescription()
 {
-    return std::make_pair(4, 0);
+    return pimpl_->state_description_;
 }
 
 

--- a/src/BayesFilters/src/sigma_point.cpp
+++ b/src/BayesFilters/src/sigma_point.cpp
@@ -18,15 +18,33 @@ using namespace Eigen;
 
 bfl::sigma_point::UTWeight::UTWeight
 (
-    std::size_t n,
+    std::size_t dof,
     const double alpha,
     const double beta,
     const double kappa
 ) :
-    mean((2 * n) + 1),
-    covariance((2 * n) + 1)
+    mean((2 * dof) + 1),
+    covariance((2 * dof) + 1)
 {
-    unscented_weights(n, alpha, beta, kappa, mean, covariance, c);
+    unscented_weights(dof, alpha, beta, kappa, mean, covariance, c);
+}
+
+
+bfl::sigma_point::UTWeight::UTWeight
+(
+    const VectorDescription& vector_description,
+    const double alpha,
+    const double beta,
+    const double kappa
+)
+{
+    /* Degree of freedom associated to input space. */
+    std::size_t dof = vector_description.total_size();
+
+    mean.resize((2 * dof) + 1);
+    covariance.resize((2 * dof) + 1);
+
+    unscented_weights(dof, alpha, beta, kappa, mean, covariance, c);
 }
 
 

--- a/src/BayesFilters/src/sigma_point.cpp
+++ b/src/BayesFilters/src/sigma_point.cpp
@@ -100,10 +100,10 @@ std::tuple<bool, GaussianMixture, MatrixXd> bfl::sigma_point::unscented_transfor
     MatrixXd input_sigma_points = sigma_point::sigma_point(input, weight.c);
 
     /* Propagate sigma points */
-    Data fun_data;
     bool valid_fun_data;
-    bfl::sigma_point::OutputSize output_size;
-    std::tie(valid_fun_data, fun_data, output_size) = function(input_sigma_points);
+    Data fun_data;
+    VectorDescription output_description;
+    std::tie(valid_fun_data, fun_data, output_description) = function(input_sigma_points);
 
     /* Stop here if function evaluation failed. */
     if (!valid_fun_data)
@@ -113,7 +113,7 @@ std::tuple<bool, GaussianMixture, MatrixXd> bfl::sigma_point::unscented_transfor
     MatrixXd prop_sigma_points = bfl::any::any_cast<MatrixXd&&>(std::move(fun_data));
 
     /* Initialize transformed gaussian. */
-    GaussianMixture output(input.components, output_size.first, output_size.second);
+    GaussianMixture output(input.components, output_description.linear_components(), output_description.circular_components());
 
     /* Initialize cross covariance matrix. */
     MatrixXd cross_covariance(input.dim, output.dim * output.components);
@@ -126,12 +126,12 @@ std::tuple<bool, GaussianMixture, MatrixXd> bfl::sigma_point::unscented_transfor
         Ref<MatrixXd> prop_sigma_points_i = prop_sigma_points.middleCols(base * i, base);
 
         /* Evaluate the mean. */
-        output.mean(i).topRows(output_size.first).noalias() = prop_sigma_points_i.topRows(output_size.first) * weight.mean;
-        output.mean(i).bottomRows(output_size.second) = directional_mean(prop_sigma_points_i.bottomRows(output_size.second), weight.mean);
+        output.mean(i).topRows(output.dim_linear).noalias() = prop_sigma_points_i.topRows(output.dim_linear) * weight.mean;
+        output.mean(i).bottomRows(output.dim_circular) = directional_mean(prop_sigma_points_i.bottomRows(output.dim_circular), weight.mean);
 
         /* Evaluate the covariance. */
-        prop_sigma_points_i.topRows(output_size.first).colwise() -= output.mean(i).topRows(output_size.first);
-        prop_sigma_points_i.bottomRows(output_size.second) = directional_sub(prop_sigma_points_i.bottomRows(output_size.second), output.mean(i).bottomRows(output_size.second));
+        prop_sigma_points_i.topRows(output.dim_linear).colwise() -= output.mean(i).topRows(output.dim_linear);
+        prop_sigma_points_i.bottomRows(output.dim_circular) = directional_sub(prop_sigma_points_i.bottomRows(output.dim_circular), output.mean(i).bottomRows(output.dim_circular));
         output.covariance(i).noalias() = prop_sigma_points_i * weight.covariance.asDiagonal() * prop_sigma_points_i.transpose();
 
         /* Evaluate the input-output cross covariance matrix
@@ -155,11 +155,11 @@ std::pair<GaussianMixture, MatrixXd> bfl::sigma_point::unscented_transform
 {
     FunctionEvaluation f = [&state_model](const Ref<const MatrixXd>& state)
                            {
-                               MatrixXd tmp(state.rows(), state.cols());
+                               MatrixXd tmp(state_model.getStateDescription().total_size(), state.cols());
 
                                state_model.motion(state, tmp);
 
-                               return std::make_tuple(true, std::move(tmp), state_model.getOutputSize());
+                               return std::make_tuple(true, std::move(tmp), state_model.getStateDescription());
                            };
     MatrixXd cross_covariance;
     GaussianMixture output;
@@ -182,7 +182,7 @@ std::pair<GaussianMixture, MatrixXd> bfl::sigma_point::unscented_transform
 
                                state_model.propagate(state, tmp);
 
-                               return std::make_tuple(true, std::move(tmp), state_model.getOutputSize());
+                               return std::make_tuple(true, std::move(tmp), state_model.getStateDescription());
                            };
 
     MatrixXd cross_covariance;
@@ -212,7 +212,7 @@ std::tuple<bool, GaussianMixture, MatrixXd> bfl::sigma_point::unscented_transfor
 
                                std::tie(valid_prediction, prediction) = meas_model.predictedMeasure(state);
 
-                               return std::make_tuple(valid_prediction, std::move(prediction), meas_model.getOutputSize());
+                               return std::make_tuple(valid_prediction, std::move(prediction), meas_model.getMeasurementDescription());
                            };
 
     bool valid;
@@ -238,7 +238,7 @@ std::tuple<bool, GaussianMixture, MatrixXd> bfl::sigma_point::unscented_transfor
 
                                std::tie(valid_prediction, prediction) = meas_model.predictedMeasure(state);
 
-                               return std::make_tuple(valid_prediction, std::move(prediction), meas_model.getOutputSize());
+                               return std::make_tuple(valid_prediction, std::move(prediction), meas_model.getMeasurementDescription());
                            };
 
     bool valid;

--- a/test/test_Gaussian_Density_UVR/main.cpp
+++ b/test/test_Gaussian_Density_UVR/main.cpp
@@ -69,9 +69,15 @@ public:
     }
 
 
-    std::pair<std::size_t, std::size_t> getOutputSize() const override
+    VectorDescription getInputDescription() const override
     {
-        return std::pair<std::size_t, std::size_t>(measurement_.size(), 0);
+        return VectorDescription(3, 0, measurement_.size());
+    }
+
+
+    VectorDescription getMeasurementDescription() const override
+    {
+        return VectorDescription(measurement_.size());
     }
 
 private:
@@ -86,12 +92,6 @@ int main()
     std::cout << "[Test] " << std::endl;
     {
         std::cout << "Constructing a simulated scenario..." << std::endl;
-
-        // Unscented Transform parameters
-        double alpha = 1.0;
-        double beta = 2.0;
-        double kappa = 0.0;
-        sigma_point::UTWeight ut_weight(3, alpha, beta, kappa);
 
         // Predicted state
         Gaussian predicted_state(3);
@@ -120,6 +120,12 @@ int main()
         predicted(5) = 1.0;
 
         SimulatedMeasurement measurement_model(measurement, predicted);
+
+        // Unscented Transform parameters
+        double alpha = 1.0;
+        double beta = 2.0;
+        double kappa = 0.0;
+        sigma_point::UTWeight ut_weight(measurement_model.getInputDescription().noiseless_description(), alpha, beta, kappa);
 
         // Propagate belief
         GaussianMixture predicted_measurement(1, 6);

--- a/test/test_UKF/main.cpp
+++ b/test/test_UKF/main.cpp
@@ -131,7 +131,7 @@ int main(int argc, char* argv[])
     /* Step 2.2 - Define the prediction step. */
 
     /* Initialize the unscented Kalman filter prediction step and pass the ownership of the state model */
-    std::unique_ptr<UKFPrediction> ukf_prediction = utils::make_unique<UKFPrediction>(std::move(wna), state_size, alpha, beta, kappa);
+    std::unique_ptr<UKFPrediction> ukf_prediction = utils::make_unique<UKFPrediction>(std::move(wna), alpha, beta, kappa);
 
 
     /* Step 3 - Correction */
@@ -158,7 +158,7 @@ int main(int argc, char* argv[])
         simulated_linear_sensor->enable_log("./", "testUKF");
 
     /* Step 3.3 - Initialize the unscented Kalman filter correction step and pass the ownership of the measurement model. */
-    std::unique_ptr<UKFCorrection> ukf_correction = utils::make_unique<UKFCorrection>(std::move(simulated_linear_sensor), state_size, alpha, beta, kappa);
+    std::unique_ptr<UKFCorrection> ukf_correction = utils::make_unique<UKFCorrection>(std::move(simulated_linear_sensor), alpha, beta, kappa);
 
 
     /* Step 4 - Assemble the unscented Kalman filter. */

--- a/test/test_UPF/main.cpp
+++ b/test/test_UPF/main.cpp
@@ -159,7 +159,7 @@ int main(int argc, char* argv[])
 
     /* Initialize the kalman particle filter prediction step that wraps a Gaussian prediction step,
        in this case an unscented kalman filter prediction step. */
-    std::unique_ptr<GaussianPrediction> upf_prediction = utils::make_unique<UKFPrediction>(std::move(wna), state_size, alpha, beta, kappa);
+    std::unique_ptr<GaussianPrediction> upf_prediction = utils::make_unique<UKFPrediction>(std::move(wna), alpha, beta, kappa);
     std::unique_ptr<PFPrediction> gpf_prediction = utils::make_unique<GPFPrediction>(std::move(upf_prediction));
 
 
@@ -200,7 +200,7 @@ int main(int argc, char* argv[])
 
     /* Initialize the particle filter correction step that wraps a Guassian correction step,
        in this case an unscented kalman filter correction step. */
-    std::unique_ptr<GaussianCorrection> upf_correction = utils::make_unique<UKFCorrection>(std::move(simulated_linear_sensor), state_size, alpha, beta, kappa);
+    std::unique_ptr<GaussianCorrection> upf_correction = utils::make_unique<UKFCorrection>(std::move(simulated_linear_sensor), alpha, beta, kappa);
     std::unique_ptr<PFCorrection> gpf_correction = utils::make_unique<GPFCorrection>(std::move(exp_likelihood), std::move(upf_correction), std::move(transition_probability_model));
 
 

--- a/test/test_UPF_MAP/main.cpp
+++ b/test/test_UPF_MAP/main.cpp
@@ -191,7 +191,7 @@ int main(int argc, char* argv[])
 
     /* Initialize the kalman particle filter prediction step that wraps a Gaussian prediction step,
        in this case an unscented kalman filter prediction step. */
-    std::unique_ptr<GaussianPrediction> upf_prediction = utils::make_unique<UKFPrediction>(std::move(wna), state_size, alpha, beta, kappa);
+    std::unique_ptr<GaussianPrediction> upf_prediction = utils::make_unique<UKFPrediction>(std::move(wna), alpha, beta, kappa);
     std::unique_ptr<PFPrediction> gpf_prediction = utils::make_unique<GPFPrediction>(std::move(upf_prediction));
 
 
@@ -232,7 +232,7 @@ int main(int argc, char* argv[])
 
     /* Initialize the particle filter correction step that wraps a Guassian correction step,
        in this case an unscented kalman filter correction step. */
-    std::unique_ptr<GaussianCorrection> upf_correction = utils::make_unique<UKFCorrection>(std::move(simulated_linear_sensor), state_size, alpha, beta, kappa);
+    std::unique_ptr<GaussianCorrection> upf_correction = utils::make_unique<UKFCorrection>(std::move(simulated_linear_sensor), alpha, beta, kappa);
     std::unique_ptr<PFCorrection> gpf_correction = utils::make_unique<GPFCorrection>(std::move(exp_likelihood), std::move(upf_correction), std::move(transition_probability_model));
 
 

--- a/test/test_mixed_KF_SUKF/main.cpp
+++ b/test/test_mixed_KF_SUKF/main.cpp
@@ -156,7 +156,7 @@ int main(int argc, char* argv[])
         simulated_linear_sensor->enable_log("./", "testKF_SUKF");
 
     /* Step 3.3 - Initialize the serial unscented Kalman filter correction step and pass the ownership of the measurement model. */
-    std::unique_ptr<GaussianCorrection> sukf_correction = utils::make_unique<SUKFCorrection>(std::move(simulated_linear_sensor), state_size, alpha, beta, kappa, 2, true);
+    std::unique_ptr<GaussianCorrection> sukf_correction = utils::make_unique<SUKFCorrection>(std::move(simulated_linear_sensor), alpha, beta, kappa, 2, true);
 
 
     /* Step 4 - Assemble the serial unscented Kalman filter */

--- a/test/test_mixed_KF_UKF/main.cpp
+++ b/test/test_mixed_KF_UKF/main.cpp
@@ -157,7 +157,7 @@ int main(int argc, char* argv[])
         simulated_linear_sensor->enable_log("./", "testKF_UKF");
 
     /* Step 3.3 - Initialize the unscented Kalman filter correction step and pass the ownership of the measurement model. */
-    std::unique_ptr<UKFCorrection> ukf_correction = utils::make_unique<UKFCorrection>(std::move(simulated_linear_sensor), state_size, alpha, beta, kappa);
+    std::unique_ptr<UKFCorrection> ukf_correction = utils::make_unique<UKFCorrection>(std::move(simulated_linear_sensor), alpha, beta, kappa);
 
 
     /* Step 4 - Assemble the mixed Kalman filter. */

--- a/test/test_mixed_UKF_KF/main.cpp
+++ b/test/test_mixed_UKF_KF/main.cpp
@@ -132,7 +132,7 @@ int main(int argc, char* argv[])
     /* Step 2.2 - Define the prediction step. */
 
     /* Initialize the unscented Kalman filter prediction step and pass the ownership of the state model. */
-    std::unique_ptr<UKFPrediction> ukf_prediction = utils::make_unique<UKFPrediction>(std::move(wna), state_size, alpha, beta, kappa);
+    std::unique_ptr<UKFPrediction> ukf_prediction = utils::make_unique<UKFPrediction>(std::move(wna), alpha, beta, kappa);
 
 
     /* Step 3 - Correction */


### PR DESCRIPTION
This PR introduces a class `VectorDescription` which helps describing the size of vectors used as state and measurements. Specifically, the information encoded in the class accounts for the size of the linear part of the state/measurement, the size of the circular part of the state/measurement and the size of the noise components.

Thanks to this PR, it will be possible to perform Unscented Kalman filtering using non-additive noise models. This requires a proper handling of the number of the sigma points (hence of the values of the Unscented transform weights). It was not possible before, as the number of noise components of the state/measurement models was not available at the moment of instantiating the weights.

More in details, in this PR:

### New interfaces
- implemented the class `VectorDescription`

### Use of new interfaces in existing classes
- provide methods `StateProcess::{getStateDescription(), getInputDescription()}` returning a `VectorDescription` of the state and input vector, respectively, of a state model
- provide methods `MeasurementModel::{getMeasurementDescription(), getInputDescription()}` returning a `VectorDescription` of the measurement and input vector, respectively, of a measurement model
- provide method `ExogenousProcess::getStateDescription` returning a `VectorDescription` of the exogenous process state
> `{StateProcess, MeasurementModel, ExogenousProcess}::getStateDescription` substitute the previous method `getOutputSize()`
- update derived classes `WhiteNoiseAcceleration`, `AdditiveStateModel`, `SimulatedLinearSensor` accordingly
- update the `sigma_point::unscented_transform()` Unscented transforms to make use of the `VectorDescription`
- update the implementation of the Kalman prediction/correction algorithms `UKFPrediction`, `UKFCorrection`  and `SUKFCorrection` in order to exploit the availability of the newly implemented methods in state models and measurement models

### Versioning
 
Given that the API has been broken, the minor version changes leading to `0.10.100`

### Tests

Tests have been updated accordingly

### Changelog

Changelog has been updated accordingly
