### PR TITLE
Several improvements and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Updated the `FunctionEvaluation` alias within `sigma_point.h` in order to use a `VectorDescription` as one of the outputs.
 - Updated implementation of variants of the `unscented_transform()` transforms within `sigma_point.h` taking into account the new definition of the `FunctionEvaluation` alias.
 - Added a constructor to the `UTWeight` struct such that it can be constructed starting from a `VectorDescription` description.
+- Added support for quaternions in `bfl::sigma_point::sigma_point()` method.
+- Added support for quaternions in `bfl::sigma_point::unscented_transform()` method.
+- Implemented method `VectorDescription::dof_size()` providing  the number of degrees of freedom associated to the vector (which might be different from `VectorDescription::total_size()`).
+- Fixed implementation of `bfl::sigma_points::UTWeight` constructor such that it uses the number of degrees of fredom of the vector to decide the number of sigma points to be initialized.
+- Added support for arguments inheriting from `Eigen::MatrixBase<T>` with different instances of `T` within the constructors of methods `bfl::utils::sum_quaternion_rotation_vector()`, `bfl::utils::diff_quaternion` and `bfl::utils::mean_quaternion()`.
 
 ##### `Filtering functions`
 - Substituted `ExogenousProcess::getOutputSize()` with `ExogenousProcess::getStateDescription()` which uses the `VectorDescription` class to describe the size of the output of the exogenous process.
@@ -17,6 +22,7 @@
 - Updated implementation of class `WhiteNoiseAcceleration` to take into account changes in the `StateModel` interface.
 - Updated implementation of class `AdditiveStateModel` to take into account changes in the `StateModel` interface.
 - Updated implementation of class `SimulatedLinearSensor` to take into account changes in the `StateModel` and `MeasurementModel` interfaces.
+- Added method `StateModel::setSamplingTime()` that sets the sampling time of the state model.
 
 ##### `Filtering algorithms`
 - Updated implementation of `SUKFCorrection` in order to extract relevant information on the measurement size using the `VectorDescription` of the adopted measurement model.

--- a/src/BayesFilters/include/BayesFilters/StateModel.h
+++ b/src/BayesFilters/include/BayesFilters/StateModel.h
@@ -42,6 +42,7 @@ public:
 
     virtual Eigen::MatrixXd getNoiseSample(const std::size_t num);
 
+    virtual bool setSamplingTime(const double& time);
 
 protected:
     StateModel() noexcept = default;

--- a/src/BayesFilters/include/BayesFilters/VectorDescription.h
+++ b/src/BayesFilters/include/BayesFilters/VectorDescription.h
@@ -40,6 +40,8 @@ public:
 
     std::size_t total_size() const;
 
+    std::size_t dof_size() const;
+
     void add_noise_components(const std::size_t& components);
 
     VectorDescription noiseless_description() const;

--- a/src/BayesFilters/include/BayesFilters/utils.h
+++ b/src/BayesFilters/include/BayesFilters/utils.h
@@ -179,8 +179,9 @@ Eigen::Matrix<DerivedScalar, 4, Eigen::Dynamic> rotation_vector_to_quaternion(co
  *
  * @return a 4 x N matrix where the i-th column is the sum between the unit quaternion and the i-th rotation vector
  */
-template<typename Derived, typename DerivedScalar = typename Derived::Scalar, bfl::utils::enable_if_t<std::is_floating_point<DerivedScalar>::value, bool> = true>
-Eigen::Matrix<DerivedScalar, 4, Eigen::Dynamic> sum_quaternion_rotation_vector(const Eigen::MatrixBase<Derived>& quaternion, const Eigen::MatrixBase<Derived>& rotation_vector)
+template<typename Derived, typename DerivedArg2, typename DerivedScalar = typename Derived::Scalar, typename DerivedArg2Scalar = typename DerivedArg2::Scalar,
+         bfl::utils::enable_if_t<std::is_floating_point<DerivedScalar>::value && std::is_same<DerivedScalar, DerivedArg2Scalar>::value, bool> = true>
+Eigen::Matrix<DerivedScalar, 4, Eigen::Dynamic> sum_quaternion_rotation_vector(const Eigen::MatrixBase<Derived>& quaternion, const Eigen::MatrixBase<DerivedArg2>& rotation_vector)
 {
     /* Move rotation vectors to their quaternionic representation. */
     Eigen::Matrix<DerivedScalar, 4, Eigen::Dynamic> vector_as_quaternion = rotation_vector_to_quaternion(rotation_vector);
@@ -221,8 +222,9 @@ Eigen::Matrix<DerivedScalar, 4, Eigen::Dynamic> sum_quaternion_rotation_vector(c
  *
  * @return a 3 x N matrix where the i-th column is the difference between the i-th left quaternion and the right quaternion
  */
-template<typename Derived, typename DerivedScalar = typename Derived::Scalar, bfl::utils::enable_if_t<std::is_floating_point<DerivedScalar>::value, bool> = true>
-Eigen::Matrix<DerivedScalar, 3, Eigen::Dynamic> diff_quaternion(const Eigen::MatrixBase<Derived>& quaternion_left, const Eigen::MatrixBase<Derived>& quaternion_right)
+template<typename Derived, typename DerivedArg2, typename DerivedScalar = typename Derived::Scalar, typename DerivedArg2Scalar = typename DerivedArg2::Scalar,
+         bfl::utils::enable_if_t<std::is_floating_point<DerivedScalar>::value && std::is_same<DerivedScalar, DerivedArg2Scalar>::value, bool> = true>
+Eigen::Matrix<DerivedScalar, 3, Eigen::Dynamic> diff_quaternion(const Eigen::MatrixBase<Derived>& quaternion_left, const Eigen::MatrixBase<DerivedArg2>& quaternion_right)
 {
     Eigen::Matrix<DerivedScalar, 4, Eigen::Dynamic> products(4, quaternion_left.cols());
 
@@ -264,8 +266,9 @@ Eigen::Matrix<DerivedScalar, 3, Eigen::Dynamic> diff_quaternion(const Eigen::Mat
  *
  * @return a 4-vector representing the weighted mean of the input quaternion set
  */
-template<typename Derived, typename DerivedScalar = typename Derived::Scalar, bfl::utils::enable_if_t<std::is_floating_point<DerivedScalar>::value, bool> = true>
-Eigen::Matrix<DerivedScalar, 4, 1> mean_quaternion(const Eigen::MatrixBase<Derived>& weight, const Eigen::MatrixBase<Derived>& quaternion)
+template<typename Derived, typename DerivedArg2, typename DerivedScalar = typename Derived::Scalar, typename DerivedArg2Scalar = typename DerivedArg2::Scalar,
+         bfl::utils::enable_if_t<std::is_floating_point<DerivedScalar>::value && std::is_same<DerivedScalar, DerivedArg2Scalar>::value, bool> = true>
+Eigen::Matrix<DerivedScalar, 4, 1> mean_quaternion(const Eigen::MatrixBase<Derived>& weight, const Eigen::MatrixBase<DerivedArg2>& quaternion)
 {
     /* Weighted outer product of quaternions. */
     Eigen::Matrix<DerivedScalar, 4, 4> outer_product_mean = Eigen::Matrix<DerivedScalar, 4, 4>::Zero();

--- a/src/BayesFilters/src/StateModel.cpp
+++ b/src/BayesFilters/src/StateModel.cpp
@@ -79,3 +79,11 @@ Eigen::MatrixXd StateModel::getNoiseSample(const std::size_t num)
 {
     throw std::runtime_error("ERROR::STATEMODEL::GETNOISESAMPLE\nERROR:\n\tMethod not implemented.");
 }
+
+
+bool StateModel::setSamplingTime(const double& time)
+{
+    /* Does nothing by default. */
+
+    return true;
+}

--- a/src/BayesFilters/src/VectorDescription.cpp
+++ b/src/BayesFilters/src/VectorDescription.cpp
@@ -69,6 +69,19 @@ std::size_t VectorDescription::total_size() const
 }
 
 
+std::size_t VectorDescription::dof_size() const
+{
+    if (circular_type == CircularType::Quaternion)
+    {
+        /* If quaternions are used, the number of degrees of freedom for the evaluation of the sigma points
+           depends on the dimensions of the tangent space that is R^3. */
+        return linear_size() + circular_components() * 3 + noise_size();
+    }
+    else
+        return total_size();
+}
+
+
 void VectorDescription::add_noise_components(const std::size_t& components)
 {
     noise_components_ += components;

--- a/src/BayesFilters/src/sigma_point.cpp
+++ b/src/BayesFilters/src/sigma_point.cpp
@@ -39,7 +39,7 @@ bfl::sigma_point::UTWeight::UTWeight
 )
 {
     /* Degree of freedom associated to input space. */
-    std::size_t dof = vector_description.total_size();
+    std::size_t dof = vector_description.dof_size();
 
     mean.resize((2 * dof) + 1);
     covariance.resize((2 * dof) + 1);

--- a/src/BayesFilters/src/sigma_point.cpp
+++ b/src/BayesFilters/src/sigma_point.cpp
@@ -142,37 +142,61 @@ std::tuple<bool, GaussianMixture, MatrixXd> bfl::sigma_point::unscented_transfor
     if (!valid_fun_data)
         return std::make_tuple(false, GaussianMixture(), MatrixXd(0, 0));
 
-    /* For now casting Data to MatrixXd. */
+    /* Unscented transforms are available only for vector-valued functions. Hence, casting Data to MatrixXd. */
     MatrixXd prop_sigma_points = bfl::any::any_cast<MatrixXd&&>(std::move(fun_data));
 
     /* Initialize transformed gaussian. */
-    GaussianMixture output(input.components, output_description.linear_components(), output_description.circular_components());
+    GaussianMixture output(input.components, output_description.linear_components(), output_description.circular_components(), output_description.circular_type == VectorDescription::CircularType::Quaternion);
 
-    /* Initialize cross covariance matrix. */
-    MatrixXd cross_covariance(input.dim, output.dim * output.components);
+    /* Initialize cross covariance matrix (noise components in the input are not considered). */
+    MatrixXd cross_covariance(input.dim_covariance - input.dim_noise, output.dim_covariance * output.components);
 
     /* Process all the components of the mixture. */
-    std::size_t base = ((input.dim * 2) + 1);
+    std::size_t base = ((input.dim_covariance * 2) + 1);
     for (std::size_t i = 0; i < input.components; i++)
     {
-        Ref<MatrixXd> input_sigma_points_i = input_sigma_points.middleCols(base * i, base);
-        Ref<MatrixXd> prop_sigma_points_i = prop_sigma_points.middleCols(base * i, base);
+        const Ref<MatrixXd> input_sigma_points_i = input_sigma_points.middleCols(base * i, base);
+        const Ref<MatrixXd> prop_sigma_points_i = prop_sigma_points.middleCols(base * i, base);
 
         /* Evaluate the mean. */
         output.mean(i).topRows(output.dim_linear).noalias() = prop_sigma_points_i.topRows(output.dim_linear) * weight.mean;
-        output.mean(i).bottomRows(output.dim_circular) = directional_mean(prop_sigma_points_i.bottomRows(output.dim_circular), weight.mean);
+
+        if (output.dim_circular > 0)
+        {
+            if (output.use_quaternion)
+                for (std::size_t j = 0; j < output.dim_circular; j++)
+                    output.mean(i).middleRows(output.dim_linear + j * 4, 4) = mean_quaternion(weight.mean, prop_sigma_points_i.middleRows(output.dim_linear + j * 4, 4));
+            else
+                output.mean(i).bottomRows(output.dim_circular) = directional_mean(prop_sigma_points_i.bottomRows(output.dim_circular), weight.mean);
+        }
 
         /* Evaluate the covariance. */
-        prop_sigma_points_i.topRows(output.dim_linear).colwise() -= output.mean(i).topRows(output.dim_linear);
-        prop_sigma_points_i.bottomRows(output.dim_circular) = directional_sub(prop_sigma_points_i.bottomRows(output.dim_circular), output.mean(i).bottomRows(output.dim_circular));
-        output.covariance(i).noalias() = prop_sigma_points_i * weight.covariance.asDiagonal() * prop_sigma_points_i.transpose();
+        MatrixXd offsets_from_mean(output.dim_covariance, input_sigma_points_i.cols());
 
-        /* Evaluate the input-output cross covariance matrix
-           (noise components in the input are not considered). */
-        Ref<MatrixXd> cross_covariance_i = cross_covariance.middleCols(output.dim * i, output.dim);
-        input_sigma_points_i.topRows(input.dim_linear).colwise() -= input.mean(i).topRows(input.dim_linear);
-        input_sigma_points_i.middleRows(input.dim_linear, input.dim_circular) = directional_sub(input_sigma_points_i.middleRows(input.dim_linear, input.dim_circular), input.mean(i).middleRows(input.dim_linear, input.dim_circular));
-        cross_covariance_i.noalias() = input_sigma_points_i.topRows(input.dim_linear + input.dim_circular) * weight.covariance.asDiagonal() * prop_sigma_points_i.transpose();
+        offsets_from_mean.topRows(output.dim_linear) = prop_sigma_points_i.topRows(output.dim_linear).colwise() - output.mean(i).topRows(output.dim_linear);
+        if (output.dim_circular > 0)
+        {
+            if (output.use_quaternion)
+                for (std::size_t j = 0; j < output.dim_circular; j++)
+                    offsets_from_mean.middleRows(output.dim_linear + j * 3, 3) = diff_quaternion(prop_sigma_points_i.middleRows(output.dim_linear + j * 4, 4), output.mean(i).middleRows(output.dim_linear + j * 4, 4));
+            else
+                offsets_from_mean.bottomRows(output.dim_circular) = directional_sub(prop_sigma_points_i.bottomRows(output.dim_circular), output.mean(i).bottomRows(output.dim_circular));
+        }
+        output.covariance(i).noalias() = offsets_from_mean * weight.covariance.asDiagonal() * offsets_from_mean.transpose();
+
+        /* Evaluate the input-output cross covariance matrix (noise components in the input are not considered). */
+        Ref<MatrixXd> cross_covariance_i = cross_covariance.middleCols(output.dim_covariance * i, output.dim_covariance);
+        MatrixXd input_offsets_from_mean(input.dim_covariance - input.dim_noise, input_sigma_points_i.cols());
+        input_offsets_from_mean.topRows(input.dim_linear) = input_sigma_points_i.topRows(input.dim_linear).colwise() - input.mean(i).topRows(input.dim_linear);
+        if (input.dim_circular > 0)
+        {
+            if (input.use_quaternion)
+                for (std::size_t j = 0; j < input.dim_circular; j++)
+                    input_offsets_from_mean.middleRows(input.dim_linear + j * 3, 3) = diff_quaternion(input_sigma_points_i.middleRows(input.dim_linear + j * 4, 4), input.mean(i).middleRows(input.dim_linear + j * 4, 4));
+            else
+                input_offsets_from_mean.bottomRows(input.dim_circular) = directional_sub(input_sigma_points_i.middleRows(input.dim_linear, input.dim_circular), input.mean(i).middleRows(input.dim_linear, input.dim_circular));
+        }
+        cross_covariance_i.noalias() = input_offsets_from_mean * weight.covariance.asDiagonal() * offsets_from_mean.transpose();
     }
 
     return std::make_tuple(true, output, cross_covariance);


### PR DESCRIPTION
Within this PR:

### Filtering functions

- Add the possibility to set the sampling time of a state model via `StateModel::setSamplingTime()`.
  > although the user could provide this parameter in the constructor of their custom class inheriting from `StateModel`, this does not allow changing the sampling time online. Indeed, the state model is tipically moved via a `unique_ptr` to a `bfl` predictor which allows accessing the state model via the the `getStateModel()` method. However, this only exposes the methods of the `StateModel` interface, not custom methods provided by the user.

- Implement method `VectorDescription::dof_size()` providing the number of degrees of freedom associated to the vector
  > this might be different from `VectorDescription::total_size()` in case quaternion components are used

### Filtering utilities
- Support quaternions components in `bfl::sigma_point::sigma_point()`
- Support quaternions components in `bfl::sigma_points::unscented_transform()`
- Fix `bfl::sigma_points::UTWeight` constructor such that it uses the number of degrees of freedom of the vector, rather than the total size of the vector, to decide the number of sigma points to be initialized
   > using the total size would work for Euclidean states but not for quaternion states. Using the degrees of freedom is correct in both cases instead
- Change signature of methods `bfl::utils::sum_quaternion_rotation_vector()`, `bfl::utils::diff_quaternion` and `bfl::utils::mean_quaternion()` such that they can support arguments inheriting from `Eigen::MatrixBase<T>` with different instances of `T`

### Changelog

Changelog has been updated accordingly