### PR TITLE
Fix compatibility with Eigen3 5.0.0 and bump version to 0.10.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ install_basic_package_files(${PROJECT_NAME}
                             NO_SET_AND_CHECK_MACRO
                             VARS_PREFIX ${PROJECT_NAME}
                             NO_CHECK_REQUIRED_COMPONENTS_MACRO
-                            DEPENDENCIES Threads)
+                            DEPENDENCIES Eigen3 Threads)
 
 # Add the uninstall target
 include(AddUninstallTarget)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ cmake_minimum_required(VERSION 3.5)
 
 project(BayesFilters
         LANGUAGES CXX
-        VERSION 0.10.0)
+        VERSION 0.10.1)
 
 set(CMAKE_CXX_STANDARD 11)
 

--- a/src/BayesFilters/CMakeLists.txt
+++ b/src/BayesFilters/CMakeLists.txt
@@ -155,7 +155,7 @@ set_target_properties(${LIBRARY_TARGET_NAME} PROPERTIES VERSION       ${${PROJEC
 
 target_include_directories(${LIBRARY_TARGET_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
                                                          "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
-if(NOT TARGET Eigen3)
+if(NOT TARGET Eigen3::Eigen)
     target_include_directories(${LIBRARY_TARGET_NAME} PUBLIC ${EIGEN3_INCLUDE_DIR})
 
     target_link_libraries(${LIBRARY_TARGET_NAME} PUBLIC Threads::Threads ${CMAKE_THREAD_LIBS_INIT})

--- a/src/BayesFilters/src/sigma_point.cpp
+++ b/src/BayesFilters/src/sigma_point.cpp
@@ -87,8 +87,11 @@ MatrixXd bfl::sigma_point::sigma_point(const GaussianMixture& state, const doubl
 
     for (std::size_t i = 0; i < state.components; i++)
     {
+#if EIGEN_VERSION_AT_LEAST(5,0,0)
+        JacobiSVD<MatrixXd, Eigen::ComputeThinU> svd = state.covariance(i).jacobiSvd<Eigen::ComputeThinU>();
+#else
         JacobiSVD<MatrixXd> svd = state.covariance(i).jacobiSvd(ComputeThinU);
-
+#endif
         MatrixXd A = svd.matrixU() * svd.singularValues().cwiseSqrt().asDiagonal();
 
         Ref<MatrixXd> sp = sigma_points.middleCols(((state.dim_covariance * 2) + 1) * i, ((state.dim_covariance * 2) + 1));


### PR DESCRIPTION
On the CMake side, there has always been a typo in the logic to link to Eigen3, but everything was working as `EIGEN3_INCLUDE_DIR` was a valid variable. As with Eigen3 5.0.0 is not exported anymore, fixing the typo is necessary to ensure that the library builds with Eigen3 5.0.0. 

On the c++ side, there was a breaking change in how SVD is invoked, see https://gitlab.com/libeigen/eigen/-/merge_requests/826/ for more details.


xref: https://github.com/robotology/robotology-superbuild/issues/1902
xref: https://github.com/robotology/robotology-superbuild/issues/1903
xref: https://github.com/conda-forge/eigen-feedstock/pull/47